### PR TITLE
♻️ chore(Dockerfile): correct casing for build stage in Dockerfile

### DIFF
--- a/client/research-indicators/Dockerfile
+++ b/client/research-indicators/Dockerfile
@@ -1,6 +1,6 @@
 #################### DEVELOPMENT STAGE ####################
 # Base image
-FROM --platform=linux/amd64 node:20-alpine as build
+FROM --platform=linux/amd64 node:20-alpine AS build
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
This pull request includes a minor change to the `Dockerfile` in the `client/research-indicators` directory. The change updates the casing of the `AS` keyword in the `FROM` instruction to follow standard Dockerfile conventions.