### PR TITLE
Standardize query formatting and improve code readability

### DIFF
--- a/server/researchindicators/eslint.config.mjs
+++ b/server/researchindicators/eslint.config.mjs
@@ -39,8 +39,7 @@ export default [
 
       parserOptions: {
         project: 'tsconfig.json',
-        tsconfigRootDir:
-          'D:\\Repositories\\alliance-research-indicators-main\\server\\researchindicators',
+        tsconfigRootDir: __dirname,
       },
     },
 

--- a/server/researchindicators/src/db/migrations/1744381163883-createIpTables.ts
+++ b/server/researchindicators/src/db/migrations/1744381163883-createIpTables.ts
@@ -1,18 +1,25 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateIpTables1744381163883 implements MigrationInterface {
-    name = 'CreateIpTables1744381163883'
+  name = 'CreateIpTables1744381163883';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE \`intellectual_property_owner\` (\`created_at\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`created_by\` bigint NULL, \`updated_at\` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`updated_by\` bigint NULL, \`is_active\` tinyint NOT NULL DEFAULT 1, \`deleted_at\` timestamp NULL, \`intellectual_property_owner_id\` bigint NOT NULL AUTO_INCREMENT, \`name\` text NOT NULL, PRIMARY KEY (\`intellectual_property_owner_id\`)) ENGINE=InnoDB`);
-        await queryRunner.query(`CREATE TABLE \`result_cap_sharing_ip\` (\`created_at\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`created_by\` bigint NULL, \`updated_at\` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`updated_by\` bigint NULL, \`is_active\` tinyint NOT NULL DEFAULT 1, \`deleted_at\` timestamp NULL, \`result_cap_sharing_ip_id\` bigint NOT NULL, \`publicity_restriction\` tinyint NULL, \`requires_futher_development\` tinyint NULL, \`asset_ip_owner_id\` bigint NULL, \`asset_ip_owner_description\` text NULL, PRIMARY KEY (\`result_cap_sharing_ip_id\`)) ENGINE=InnoDB`);
-        await queryRunner.query(`ALTER TABLE \`result_cap_sharing_ip\` ADD CONSTRAINT \`FK_d6e8ad34be1ffeda9eefbc778e3\` FOREIGN KEY (\`asset_ip_owner_id\`) REFERENCES \`intellectual_property_owner\`(\`intellectual_property_owner_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`intellectual_property_owner\` (\`created_at\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`created_by\` bigint NULL, \`updated_at\` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`updated_by\` bigint NULL, \`is_active\` tinyint NOT NULL DEFAULT 1, \`deleted_at\` timestamp NULL, \`intellectual_property_owner_id\` bigint NOT NULL AUTO_INCREMENT, \`name\` text NOT NULL, PRIMARY KEY (\`intellectual_property_owner_id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE \`result_cap_sharing_ip\` (\`created_at\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`created_by\` bigint NULL, \`updated_at\` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`updated_by\` bigint NULL, \`is_active\` tinyint NOT NULL DEFAULT 1, \`deleted_at\` timestamp NULL, \`result_cap_sharing_ip_id\` bigint NOT NULL, \`publicity_restriction\` tinyint NULL, \`requires_futher_development\` tinyint NULL, \`asset_ip_owner_id\` bigint NULL, \`asset_ip_owner_description\` text NULL, PRIMARY KEY (\`result_cap_sharing_ip_id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_cap_sharing_ip\` ADD CONSTRAINT \`FK_d6e8ad34be1ffeda9eefbc778e3\` FOREIGN KEY (\`asset_ip_owner_id\`) REFERENCES \`intellectual_property_owner\`(\`intellectual_property_owner_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`result_cap_sharing_ip\` DROP FOREIGN KEY \`FK_d6e8ad34be1ffeda9eefbc778e3\``);
-        await queryRunner.query(`DROP TABLE \`result_cap_sharing_ip\``);
-        await queryRunner.query(`DROP TABLE \`intellectual_property_owner\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_cap_sharing_ip\` DROP FOREIGN KEY \`FK_d6e8ad34be1ffeda9eefbc778e3\``,
+    );
+    await queryRunner.query(`DROP TABLE \`result_cap_sharing_ip\``);
+    await queryRunner.query(`DROP TABLE \`intellectual_property_owner\``);
+  }
 }

--- a/server/researchindicators/src/db/migrations/1744385171102-addedFKCapIpToResult.ts
+++ b/server/researchindicators/src/db/migrations/1744385171102-addedFKCapIpToResult.ts
@@ -1,14 +1,17 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddedFKCapIpToResult1744385171102 implements MigrationInterface {
-    name = 'AddedFKCapIpToResult1744385171102'
+  name = 'AddedFKCapIpToResult1744385171102';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`result_cap_sharing_ip\` ADD CONSTRAINT \`FK_edaef5d259ac93f16c555baec82\` FOREIGN KEY (\`result_cap_sharing_ip_id\`) REFERENCES \`results\`(\`result_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_cap_sharing_ip\` ADD CONSTRAINT \`FK_edaef5d259ac93f16c555baec82\` FOREIGN KEY (\`result_cap_sharing_ip_id\`) REFERENCES \`results\`(\`result_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`result_cap_sharing_ip\` DROP FOREIGN KEY \`FK_edaef5d259ac93f16c555baec82\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_cap_sharing_ip\` DROP FOREIGN KEY \`FK_edaef5d259ac93f16c555baec82\``,
+    );
+  }
 }

--- a/server/researchindicators/src/db/migrations/1744387517869-addedpotential_assetToCapIp.ts
+++ b/server/researchindicators/src/db/migrations/1744387517869-addedpotential_assetToCapIp.ts
@@ -1,14 +1,19 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddedpotentialAssetToCapIp1744387517869 implements MigrationInterface {
-    name = 'AddedpotentialAssetToCapIp1744387517869'
+export class AddedpotentialAssetToCapIp1744387517869
+  implements MigrationInterface
+{
+  name = 'AddedpotentialAssetToCapIp1744387517869';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`result_cap_sharing_ip\` ADD \`potential_asset\` tinyint NULL`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_cap_sharing_ip\` ADD \`potential_asset\` tinyint NULL`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`result_cap_sharing_ip\` DROP COLUMN \`potential_asset\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_cap_sharing_ip\` DROP COLUMN \`potential_asset\``,
+    );
+  }
 }

--- a/server/researchindicators/src/domain/entities/green-checks/green-checks.service.ts
+++ b/server/researchindicators/src/domain/entities/green-checks/green-checks.service.ts
@@ -213,6 +213,7 @@ export class GreenChecksService {
       if (result_status_id === ResultStatusEnum.SUBMITTED) {
         this.prepareEmailForSubmission(
           resultId,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           (data) =>
             `[ROAR] Result ${resultId}, Action Required: Review New Result Submission`,
         );


### PR DESCRIPTION
This pull request introduces several changes to improve code quality, maintainability, and consistency across the project. The most important updates include replacing hardcoded paths with dynamic values, improving TypeScript and database migration code formatting, and adding a minor comment for clarity in a service file.

### Code Quality and Maintainability Improvements:

* Updated `tsconfigRootDir` in `eslint.config.mjs` to use `__dirname` instead of a hardcoded path, improving portability and maintainability. (`server/researchindicators/eslint.config.mjs`, [server/researchindicators/eslint.config.mjsL42-R42](diffhunk://#diff-9b10c118118515b451e09823338b3032acaf257e2b8995aef199dba68735aea8L42-R42))

* Standardized import statements in migration files to use single quotes instead of double quotes, aligning with project style guidelines. (`server/researchindicators/src/db/migrations/1744381163883-createIpTables.ts`, [[1]](diffhunk://#diff-0fd493b1f988dcad8f65204fcbf8ddb9151f411254cf3e488354f8468be3ac88L1-L17); `server/researchindicators/src/db/migrations/1744385171102-addedFKCapIpToResult.ts`, [[2]](diffhunk://#diff-05de2a5c6d789b7f89cfb40433a9955ac96d088c717f1c297f21cbe9e4755325L1-L13); `server/researchindicators/src/db/migrations/1744387517869-addedpotential_assetToCapIp.ts`, [[3]](diffhunk://#diff-c54aa8d9564617b04845f0e8ff8ebed7c15985b773c83f1c65d1d518cb7b4e12L1-L13)

* Reformatted database migration queries to use multiline strings for better readability and consistency. (`server/researchindicators/src/db/migrations/1744381163883-createIpTables.ts`, [[1]](diffhunk://#diff-0fd493b1f988dcad8f65204fcbf8ddb9151f411254cf3e488354f8468be3ac88L1-L17); `server/researchindicators/src/db/migrations/1744385171102-addedFKCapIpToResult.ts`, [[2]](diffhunk://#diff-05de2a5c6d789b7f89cfb40433a9955ac96d088c717f1c297f21cbe9e4755325L1-L13); `server/researchindicators/src/db/migrations/1744387517869-addedpotential_assetToCapIp.ts`, [[3]](diffhunk://#diff-c54aa8d9564617b04845f0e8ff8ebed7c15985b773c83f1c65d1d518cb7b4e12L1-L13)

### Minor Enhancements:

* Added an inline comment to disable an ESLint rule in `green-checks.service.ts` for a callback parameter that is intentionally unused, improving clarity for future developers. (`server/researchindicators/src/domain/entities/green-checks/green-checks.service.ts`, [server/researchindicators/src/domain/entities/green-checks/green-checks.service.tsR216](diffhunk://#diff-54cbe2c8e4d68d39128a6568de06a0b44d16e84fb56a0a6ce6d8e684e7fbbb8fR216))