### PR TITLE
🔥 hotfix(green-checks): update result URL to use dynamic result code from ResultsUtil

### DIFF
--- a/server/researchindicators/src/domain/entities/green-checks/green-checks.service.ts
+++ b/server/researchindicators/src/domain/entities/green-checks/green-checks.service.ts
@@ -239,7 +239,7 @@ export class GreenChecksService {
       .getDataForReviseResult(resultId, toStatusId, fromStatusId)
       .then(async (data) => {
         data['url'] =
-          `${this.appConfig.ARI_CLIENT_HOST}/result/${resultId}/general-information`;
+          `${this.appConfig.ARI_CLIENT_HOST}/result/${this._resultsUtil.resultCode}/general-information`;
         const template = await this.templateService._getTemplate(
           templateName,
           data,


### PR DESCRIPTION
This pull request includes a small but important change to the `GreenChecksService` class in the `green-checks.service.ts` file. The change updates the URL generation logic to use a `resultCode` property from the `_resultsUtil` service instead of directly using the `resultId`.

* [`server/researchindicators/src/domain/entities/green-checks/green-checks.service.ts`](diffhunk://#diff-54cbe2c8e4d68d39128a6568de06a0b44d16e84fb56a0a6ce6d8e684e7fbbb8fL242-R242): Modified the URL construction logic to replace `resultId` with `this._resultsUtil.resultCode` for generating the `general-information` URL.