### PR TITLE
♻️ chore(docker): remove unnecessary script execution flag from npm ci in Dockerfile

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -31,7 +31,7 @@ CMD ["npm", "run", "start"]
 FROM base AS build
 
 # Install production dependencies securely (no script execution)
-RUN npm ci --only=production --ignore-scripts
+RUN npm ci --only=production
 
 # Copy source code and config files
 COPY src ./src


### PR DESCRIPTION
This pull request includes a small change to the `server/researchindicators/Dockerfile`. The change removes the `--ignore-scripts` flag from the `npm ci` command, allowing post-install scripts to execute during the installation of production dependencies.