### PR TITLE
♻️ chore(docker): modify development stage in Dockerfile to ignore scripts during base image build

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -9,7 +9,7 @@ COPY package*.json ./
 
 
 #################### DEVELOPMENT STAGE ####################
-FROM base AS development
+FROM base AS development --ignore-scripts
 
 # Install all dependencies (scripts allowed in dev)
 RUN npm install


### PR DESCRIPTION
This pull request modifies the `server/researchindicators/Dockerfile` to adjust the behavior of the development stage by ignoring scripts during the build process.

Dockerfile modification:

* [`server/researchindicators/Dockerfile`](diffhunk://#diff-589380f2b3efdc9448c17bd98672d556b5207bc14a2e1d32c6705dcd05d88811L12-R12): Changed the `FROM base AS development` line to `FROM base AS development --ignore-scripts` to prevent scripts from running during the development stage.