### PR TITLE
♻️ chore(docker): update development stage in Dockerfile to allow script execution during npm install

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -9,10 +9,10 @@ COPY package*.json ./
 
 
 #################### DEVELOPMENT STAGE ####################
-FROM base AS development --ignore-scripts
+FROM base AS development
 
 # Install all dependencies (scripts allowed in dev)
-RUN npm install
+RUN npm install  --ignore-scripts
 
 # Copy source code and config files
 COPY src ./src


### PR DESCRIPTION
This pull request updates the `Dockerfile` in the `server/researchindicators` directory to adjust the behavior of the development stage. The most important change is the addition of the `--ignore-scripts` flag to the `npm install` command, which alters how dependencies are installed during development.

Changes to the development stage in the `Dockerfile`:

* Removed the `--ignore-scripts` flag from the `FROM base AS development` line, allowing scripts to run during the base image definition.
* Added the `--ignore-scripts` flag to the `npm install` command, ensuring that scripts are ignored when installing dependencies in the development stage.