### PR TITLE
♻️ chore(Dockerfile): update npm install command to ignore scripts during development

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -12,7 +12,7 @@ COPY package*.json ./
 FROM base AS development
 
 # Install all dependencies (scripts allowed in dev)
-RUN npm install
+RUN npm install  --ignore-scripts
 
 # Copy source code and config files
 COPY src ./src


### PR DESCRIPTION
This pull request includes a small change to the `server/researchindicators/Dockerfile`. The change modifies the `npm install` command to include the `--ignore-scripts` flag, preventing scripts from being executed during the installation process.