### PR TITLE
Star mvp project indicators

### DIFF
--- a/server/researchindicators/src/db/migrations/1756389433866-STARmvpCustomFields.ts
+++ b/server/researchindicators/src/db/migrations/1756389433866-STARmvpCustomFields.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class STARmvpCustomFields1756389433866 implements MigrationInterface {
+    name = 'STARmvpCustomFields1756389433866'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_1\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_2\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_3\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_4\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_5\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_6\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_7\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_8\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_9\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` ADD \`custom_field_10\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_1\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_2\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_3\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_4\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_5\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_6\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_7\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_8\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_9\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` ADD \`custom_field_10\` text NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_10\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_9\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_8\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_7\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_6\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_5\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_4\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_3\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_2\``);
+        await queryRunner.query(`ALTER TABLE \`project_groups\` DROP COLUMN \`custom_field_1\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_10\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_9\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_8\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_7\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_6\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_5\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_4\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_3\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_2\``);
+        await queryRunner.query(`ALTER TABLE \`groups_items\` DROP COLUMN \`custom_field_1\``);
+    }
+
+}

--- a/server/researchindicators/src/domain/entities/groups_items/dto/group-item-action.dto.ts
+++ b/server/researchindicators/src/domain/entities/groups_items/dto/group-item-action.dto.ts
@@ -22,6 +22,46 @@ export class StructureDto {
   @IsOptional()
   name_level_2?: string;
 
+  @IsString()
+  @IsOptional()
+  custom_field_1?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_2?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_3?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_4?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_5?: string;
+
+   @IsString()
+  @IsOptional()
+  custom_field_6?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_7?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_8?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_9?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_10?: string;
+
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ParentItemDto)
@@ -40,6 +80,46 @@ export class ChildItemDto {
   @IsString()
   @IsNotEmpty()
   code: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_1?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_2?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_3?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_4?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_5?: string;
+
+   @IsString()
+  @IsOptional()
+  custom_field_6?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_7?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_8?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_9?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_10?: string;
 
   @IsOptional()
   @IsArray()
@@ -72,6 +152,48 @@ export class ParentItemDto {
   @ValidateNested({ each: true })
   @Type(() => IndicatorDto)
   indicators?: IndicatorDto[];
+}
+
+export class CustomFieldsDto {
+  @IsString()
+  @IsOptional()
+  custom_field_1?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_2?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_3?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_4?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_5?: string;
+
+   @IsString()
+  @IsOptional()
+  custom_field_6?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_7?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_8?: string;
+
+  @IsString()
+  @IsOptional()
+  custom_field_9?: string;
+  
+  @IsString()
+  @IsOptional()
+  custom_field_10?: string;
 }
 
 export class IndicatorDto {

--- a/server/researchindicators/src/domain/entities/groups_items/dto/group-item-action.dto.ts
+++ b/server/researchindicators/src/domain/entities/groups_items/dto/group-item-action.dto.ts
@@ -14,53 +14,10 @@ export class StructureDto {
   @IsNotEmpty()
   agreement_id: string;
 
-  @IsString()
-  @IsOptional()
-  name_level_1?: string;
-
-  @IsString()
-  @IsOptional()
-  name_level_2?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_1?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_2?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_3?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_4?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_5?: string;
-
-   @IsString()
-  @IsOptional()
-  custom_field_6?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_7?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_8?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_9?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_10?: string;
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => LevelDto)
+  levels: LevelDto[];
 
   @IsArray()
   @ValidateNested({ each: true })
@@ -68,64 +25,38 @@ export class StructureDto {
   structures: ParentItemDto[];
 }
 
-export class ChildItemDto {
+export class LevelDto {
   @IsOptional()
-  @IsNumber()
-  id?: number;
-
   @IsString()
-  @IsNotEmpty()
-  name: string;
-
-  @IsString()
-  @IsNotEmpty()
-  code: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_1?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_2?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_3?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_4?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_5?: string;
-
-   @IsString()
-  @IsOptional()
-  custom_field_6?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_7?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_8?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_9?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_10?: string;
+  name_level_1?: string;
 
   @IsOptional()
+  @IsString()
+  name_level_2?: string;
+
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => IndicatorDto)
-  indicators?: IndicatorDto[];
+  @Type(() => CustomFieldDto)
+  custom_fields: CustomFieldDto[];
+}
+export class CustomFieldDto {
+  @IsNotEmpty()
+  @IsInt()
+  fieldID: number;
+
+  @IsNotEmpty()
+  @IsString()
+  field_name: string;
+}
+
+export class CustomValueDto {
+  @IsNotEmpty()
+  @IsInt()
+  field: number;
+
+  @IsNotEmpty()
+  @IsString()
+  field_value: string;
 }
 
 export class ParentItemDto {
@@ -144,6 +75,12 @@ export class ParentItemDto {
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
+  @Type(() => CustomValueDto)
+  custom_values?: CustomValueDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
   @Type(() => ChildItemDto)
   items?: ChildItemDto[];
 
@@ -154,95 +91,34 @@ export class ParentItemDto {
   indicators?: IndicatorDto[];
 }
 
-export class CustomFieldsDto {
-  @IsString()
+export class ChildItemDto {
   @IsOptional()
-  custom_field_1?: string;
+  @IsNumber()
+  id?: number;
 
   @IsString()
-  @IsOptional()
-  custom_field_2?: string;
+  @IsNotEmpty()
+  name: string;
 
   @IsString()
-  @IsOptional()
-  custom_field_3?: string;
+  @IsNotEmpty()
+  code: string;
 
-  @IsString()
   @IsOptional()
-  custom_field_4?: string;
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CustomValueDto)
+  custom_values?: CustomValueDto[];
 
-  @IsString()
   @IsOptional()
-  custom_field_5?: string;
-
-   @IsString()
-  @IsOptional()
-  custom_field_6?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_7?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_8?: string;
-
-  @IsString()
-  @IsOptional()
-  custom_field_9?: string;
-  
-  @IsString()
-  @IsOptional()
-  custom_field_10?: string;
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => IndicatorDto)
+  indicators?: IndicatorDto[];
 }
 
 export class IndicatorDto {
   @IsNotEmpty()
   @IsNumber()
-  id?: number;
-
-  @IsString()
-  @IsOptional()
-  name: string;
-
-  @IsString()
-  @IsOptional()
-  code: string;
-
-  @IsOptional()
-  @IsString()
-  description?: string;
-
-  @IsOptional()
-  @IsInt()
-  level?: number;
-
-  @IsString()
-  @IsOptional()
-  number_type: string;
-
-  @IsString()
-  @IsOptional()
-  number_format: string;
-
-  @IsArray()
-  @Type(() => Number)
-  @IsInt({ each: true })
-  years: number[];
-
-  @IsString()
-  @IsOptional()
-  target_unit: string;
-
-  @IsNumber()
-  @IsOptional()
-  target_value: number;
-
-  @IsNumber()
-  @IsOptional()
-  base_line: number;
-
-  @IsString()
-  @IsOptional()
-  type: string;
+  id: number;
 }

--- a/server/researchindicators/src/domain/entities/groups_items/entities/groups_item.entity.ts
+++ b/server/researchindicators/src/domain/entities/groups_items/entities/groups_item.entity.ts
@@ -42,6 +42,36 @@ export class GroupItem extends AuditableEntity {
   @Column({ name: 'parent_id', type: 'int', nullable: true })
   parent_id?: number | null;
 
+  @Column({ name: 'custom_field_1', type: 'text', nullable: true })
+  custom_field_1?: string | null;
+
+  @Column({ name: 'custom_field_2', type: 'text', nullable: true })
+  custom_field_2?: string | null;
+
+  @Column({ name: 'custom_field_3', type: 'text', nullable: true })
+  custom_field_3?: string | null;
+
+  @Column({ name: 'custom_field_4', type: 'text', nullable: true })
+  custom_field_4?: string | null;
+
+  @Column({ name: 'custom_field_5', type: 'text', nullable: true })
+  custom_field_5?: string | null;
+
+  @Column({ name: 'custom_field_6', type: 'text', nullable: true })
+  custom_field_6?: string | null;
+
+  @Column({ name: 'custom_field_7', type: 'text', nullable: true })
+  custom_field_7?: string | null;
+
+  @Column({ name: 'custom_field_8', type: 'text', nullable: true })
+  custom_field_8?: string | null;
+
+  @Column({ name: 'custom_field_9', type: 'text', nullable: true })
+  custom_field_9?: string | null;
+
+  @Column({ name: 'custom_field_10', type: 'text', nullable: true })
+  custom_field_10?: string | null;
+
   @ManyToOne(() => GroupItem, (group) => group.childGroups, {
     nullable: true,
     onDelete: 'SET NULL',

--- a/server/researchindicators/src/domain/entities/groups_items/groups_items.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/groups_items/groups_items.controller.spec.ts
@@ -42,9 +42,22 @@ describe('GroupsItemsController', () => {
     it('should return formatted response with structure', async () => {
       const agreementId = 'test-id';
       const mockResponse = {
-        name_level_1: 'Level 1 Name',
-        name_level_2: 'Level 2 Name',
-        structures: [{ id: 1, name: 'Test Structure' }]
+        levels: [
+          {
+            custom_fields: [{ fieldID: 1, field_name: 'custom_field_1' }],
+            name_level_1: 'Test Level 1'
+          },
+          {
+            custom_fields: [{ fieldID: 2, field_name: 'custom_field_2' }], 
+            name_level_2: 'Test Level 2'
+          }
+        ],
+        structures: [
+          {
+            id: 1,
+            name: 'Test Structure'
+          }
+        ]
       };
       jest.spyOn(service, 'findAll').mockResolvedValue(mockResponse);
       const result = await controller.findAll(agreementId);
@@ -61,8 +74,16 @@ describe('GroupsItemsController', () => {
     it('should handle empty structures', async () => {
       const agreementId = 'test-id';
       const mockResponse = {
-        name_level_1: '',
-        name_level_2: '',
+        levels: [
+          {
+            custom_fields: [{ fieldID: 1, field_name: 'custom_field_1' }],
+            name_level_1: 'Test Level 1'
+          },
+          {
+            custom_fields: [{ fieldID: 2, field_name: 'custom_field_2' }], 
+            name_level_2: 'Test Level 2'
+          }
+        ],
         structures: []
       };
       
@@ -79,8 +100,16 @@ describe('GroupsItemsController', () => {
     it('should return formatted response after syncing structures', async () => {
       const dto: StructureDto = {
         agreement_id: 'test-agreement-id',
-        name_level_1: 'Test Level 1',
-        name_level_2: 'Test Level 2',
+        levels: [
+          {
+            custom_fields: [{ fieldID: 1, field_name: 'custom_field_1' }],
+            name_level_1: 'Test Level 1'
+          },
+          {
+            custom_fields: [{ fieldID: 2, field_name: 'custom_field_2' }], 
+            name_level_2: 'Test Level 2'
+          }
+        ],
         structures: [
           {
             id: 1,
@@ -123,8 +152,16 @@ describe('GroupsItemsController', () => {
     it('should handle sync without data', async () => {
       const dto: StructureDto = {
         agreement_id: 'test-agreement-id',
-        name_level_1: 'Test Level 1',
-        name_level_2: 'Test Level 2',
+        levels: [
+          {
+            custom_fields: [{ fieldID: 1, field_name: 'custom_field_1' }],
+            name_level_1: 'Test Level 1'
+          },
+          {
+            custom_fields: [{ fieldID: 2, field_name: 'custom_field_2' }], 
+            name_level_2: 'Test Level 2'
+          }
+        ],
         structures: []
       };
       

--- a/server/researchindicators/src/domain/entities/groups_items/groups_items.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/groups_items/groups_items.service.spec.ts
@@ -3,6 +3,19 @@ import { GroupsItemsService } from './groups_items.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { GroupItem } from './entities/groups_item.entity';
 import { DataSource, Repository } from 'typeorm';
+import { ProjectGroup } from '../project_groups/entities/project_group.entity';
+import { EntityManager } from 'typeorm';
+
+
+jest.mock('../../shared/utils/clean-custom-fields', () => ({
+  cleanCustomFields: jest.fn().mockImplementation((obj) => {
+    // Simula que retorna los campos custom_field_X si existen
+    return Object.keys(obj)
+      .filter((k) => k.startsWith('custom_field_'))
+      .map((k) => obj[k])
+      .filter((v) => v !== undefined);
+  }),
+}));
 
 describe('GroupsItemsService', () => {
   let service: GroupsItemsService;
@@ -21,8 +34,8 @@ describe('GroupsItemsService', () => {
       transaction: jest.fn(),
       getRepository: jest.fn().mockReturnValue({
         find: jest.fn().mockResolvedValue([
-          { name: 'Level1', level: 1 },
-          { name: 'Level2', level: 2 },
+          { name: 'Level1', level: 1, custom_field_1: 'cf1' },
+          { name: 'Level2', level: 2, custom_field_2: 'cf2' },
         ]),
         createQueryBuilder: jest.fn(),
         save: jest.fn(),
@@ -93,257 +106,132 @@ describe('GroupsItemsService', () => {
       repo.createQueryBuilder = jest.fn().mockReturnValue(qb);
 
       const result = await service.findAll('agreement1');
-      expect(result.name_level_1).toBe('Level1');
-      expect(result.name_level_2).toBe('Level2');
+      expect(result.levels.length).toBe(2);
+      expect(result.levels[0].custom_fields.length).toBe(1);
       expect(result.structures.length).toBe(1);
       expect(result.structures[0].items.length).toBe(1);
       expect(result.structures[0].indicators.length).toBe(1);
     });
-  });
 
-  describe('syncStructures2', () => {
-    function createMockQueryBuilder() {
-      return {
+    it('should skip groups without name or code', async () => {
+      const mockGroups = [
+        { id: 1, name: null, code: 'P1', parent_id: null, indicatorPerItem: [] },
+        { id: 2, name: 'Parent', code: null, parent_id: null, indicatorPerItem: [] },
+        { id: 3, name: 'Valid', code: 'C1', parent_id: null, indicatorPerItem: [] },
+      ];
+      const qb: any = {
         leftJoinAndSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        from: jest.fn().mockReturnThis(),
-        innerJoin: jest.fn().mockReturnThis(),
-        leftJoin: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        having: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        offset: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        take: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(mockGroups),
+      };
+      repo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      const result = await service.findAll('agreement1');
+      expect(result.structures.length).toBe(1);
+      expect(result.structures[0].name).toBe('Valid');
+    });
+
+    it('should handle empty groups', async () => {
+      const qb: any = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue([]),
-        getOne: jest.fn().mockResolvedValue(null),
-        getRawMany: jest.fn().mockResolvedValue([]),
-        getRawOne: jest.fn().mockResolvedValue(null),
-        getCount: jest.fn().mockResolvedValue(0),
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-        delete: jest.fn().mockReturnThis(),
-        insert: jest.fn().mockReturnThis(),
-        into: jest.fn().mockReturnThis(),
-        values: jest.fn().mockReturnThis(),
-        execute: jest.fn().mockResolvedValue({ affected: 0 }),
       };
-    }
+      repo.createQueryBuilder = jest.fn().mockReturnValue(qb);
 
-    function createMockEntityManager() {
-      return {
-        find: jest.fn().mockResolvedValue([{ id: 111, is_active: true }]),
-        create: jest.fn().mockImplementation((_, obj) => obj),
-        save: jest.fn().mockImplementation(async (obj) => ({
-          ...obj,
-          id: Math.floor(Math.random() * 1000),
-        })),
-        update: jest.fn().mockResolvedValue({ affected: 1 }),
-        createQueryBuilder: jest.fn().mockReturnValue(createMockQueryBuilder()),
+      const result = await service.findAll('agreement1');
+      expect(result.structures).toEqual([]);
+      expect(result.levels.length).toBe(2);
+    });
+  });
+
+  describe('processLevels', () => {
+    it('should upsert levels', async () => {
+      const manager = {
         findOne: jest.fn().mockResolvedValue(null),
-        remove: jest.fn().mockResolvedValue({}),
-        softDelete: jest.fn().mockResolvedValue({ affected: 0 }),
-        query: jest.fn().mockResolvedValue({}),
-      };
-    }
-
-    it('should create new parent and child when none exist', async () => {
-      const managerMock = createMockEntityManager();
-      dataSource.transaction = jest
-        .fn()
-        .mockImplementation(async (cb) => cb(managerMock));
-
-      const dtoCreate = {
-        agreement_id: 'agreement1',
-        name_level_1: 'Level1',
-        name_level_2: 'Level2',
-        structures: [
-          {
-            name: 'Parent',
-            code: 'P1',
-            items: [
-              {
-                name: 'Child',
-                code: 'C1',
-                indicators: [
-                  {
-                    name: 'Child Indicator',
-                    description: 'Child test indicator',
-                    code: 'CIND1',
-                    number_type: 'type2',
-                    number_format: 'format2',
-                    years: [2023],
-                    target_unit: 'unit2',
-                    target_value: 50,
-                    base_line: 25,
-                    type: 'type2',
-                    level: 2,
-                  },
-                ],
-              },
-            ],
-            indicators: [
-              {
-                name: 'Indicator 1',
-                description: 'Test indicator',
-                code: 'IND1',
-                number_type: 'type1',
-                number_format: 'format1',
-                years: [2023, 2024],
-                target_unit: 'unit1',
-                target_value: 100,
-                base_line: 50,
-                type: 'type1',
-                level: 1,
-              },
-            ],
-          },
-        ],
-      };
-
-      const result = await service.syncStructures2(dtoCreate);
-      expect(result).toEqual({
-        message: 'Sincronización de padres completada',
-      });
-      expect(managerMock.save).toHaveBeenCalled();
-      expect(managerMock.create).toHaveBeenCalled();
-      expect(managerMock.update).toHaveBeenCalled();
-    });
-
-    it('should update existing parent and child', async () => {
-      const parentId = 123;
-      const childId = 456;
-      const managerMock = createMockEntityManager();
-      managerMock.find.mockImplementationOnce(async () => [
-        {
-          id: parentId,
-          name: 'OldParent',
-          code: 'OP',
-          agreement_id: 'agreement1',
-          parent_id: null,
-        },
-      ]);
-
-      // Mock the second call for existing children
-      managerMock.find.mockImplementationOnce(async () => [
-        {
-          id: childId,
-          name: 'OldChild',
-          code: 'OC',
-          agreement_id: 'agreement1',
-          parent_id: parentId,
-        },
-      ]);
-
-      // Mock save to return the saved entity with id
-      managerMock.save.mockImplementation(async (entity) => ({
-        ...entity,
-        id: entity.id || Math.floor(Math.random() * 1000),
-      }));
-
-      dataSource.transaction = jest
-        .fn()
-        .mockImplementation(async (cb) => cb(managerMock));
-
-      const dtoUpdate = {
-        agreement_id: 'agreement1',
-        name_level_1: 'Level1',
-        name_level_2: 'Level2',
-        structures: [
-          {
-            id: parentId,
-            name: 'UpdatedParent',
-            code: 'UP1',
-            indicators: [],
-            items: [
-              {
-                id: childId,
-                name: 'UpdatedChild',
-                code: 'UC1',
-                indicators: [],
-              },
-            ],
-          },
-        ],
-      };
-
-      const result = await service.syncStructures2(dtoUpdate);
-      expect(result).toEqual({
-        message: 'Sincronización de padres completada',
-      });
-      expect(managerMock.save).toHaveBeenCalled();
-    });
-
-    it('should deactivate parents and children not in payload', async () => {
-      const parentId = 111;
-      const managerMock = createMockEntityManager();
-      dataSource.transaction = jest
-        .fn()
-        .mockImplementation(async (cb) => cb(managerMock));
+        create: jest.fn().mockImplementation((_, obj) => obj),
+        save: jest.fn().mockResolvedValue({}),
+      } as unknown as EntityManager;
 
       const dto = {
         agreement_id: 'agreement1',
         name_level_1: 'Level1',
         name_level_2: 'Level2',
-        structures: [],
       };
 
-      const result = await service.syncStructures2(dto);
-      expect(result).toEqual({
-        message: 'Sincronización de padres completada',
-      });
-      expect(managerMock.update).toHaveBeenCalledWith(
-        expect.anything(),
-        { id: parentId },
-        expect.objectContaining({ is_active: false }),
+      await service.processLevels(dto, manager);
+      expect(manager.create).toHaveBeenCalledWith(ProjectGroup, expect.objectContaining({ name: 'Level1', level: 1 }));
+      expect(manager.create).toHaveBeenCalledWith(ProjectGroup, expect.objectContaining({ name: 'Level2', level: 2 }));
+      expect(manager.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('should remove levels if name not provided', async () => {
+      const manager = {
+        findOne: jest.fn().mockResolvedValue({ is_active: true, name: 'Level1', level: 1 }),
+        save: jest.fn().mockResolvedValue({}),
+        createQueryBuilder: jest.fn().mockReturnValue({
+          update: jest.fn().mockReturnThis(),
+          set: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          execute: jest.fn().mockResolvedValue({}),
+        }),
+      } as unknown as EntityManager;
+
+      const dto = {
+        agreement_id: 'agreement1',
+        name_level_1: null,
+        name_level_2: null,
+      };
+
+      await service.processLevels(dto, manager);
+      expect(manager.save).toHaveBeenCalled();
+      expect(manager.createQueryBuilder).toHaveBeenCalled();
+    });
+  });
+
+  describe('syncGroupItemIndicators', () => {
+    it('should insert new indicator relation', async () => {
+      const manager = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          from: jest.fn().mockReturnThis(),
+          innerJoin: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          getRawMany: jest.fn().mockResolvedValue([]),
+        }),
+        query: jest.fn().mockResolvedValue({}),
+      } as unknown as EntityManager;
+
+      await service['syncGroupItemIndicators'](1, [{ id: 2 }], 'agreement1', manager);
+      expect(manager.query).toHaveBeenCalledWith(
+        'INSERT INTO indicator_per_item (group_item_id, project_indicator_id) VALUES (?, ?)',
+        [1, 2],
       );
     });
 
-    it('should handle indicators creation and association', async () => {
-      const managerMock = createMockEntityManager();
-      dataSource.transaction = jest
-        .fn()
-        .mockImplementation(async (cb) => cb(managerMock));
+    it('should delete indicator relation not in payload', async () => {
+      const manager = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          from: jest.fn().mockReturnThis(),
+          innerJoin: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          andWhere: jest.fn().mockReturnThis(),
+          getRawMany: jest.fn().mockResolvedValue([{ indicatorId: 2 }]),
+          delete: jest.fn().mockReturnThis(),
+          execute: jest.fn().mockResolvedValue({}),
+        }),
+        query: jest.fn().mockResolvedValue({}),
+      } as unknown as EntityManager;
 
-      const dtoIndicators = {
-        agreement_id: 'agreement1',
-        name_level_1: 'Level1',
-        name_level_2: 'Level2',
-        structures: [
-          {
-            name: 'Parent',
-            code: 'P1',
-            indicators: [
-              {
-                id: 1,
-                name: 'Ind1',
-                code: 'C1',
-                description: 'desc',
-                number_type: 'int',
-                number_format: 'decimal',
-                years: [2022],
-                target_unit: 'unit',
-                target_value: 100,
-                base_line: 10,
-                type: 'type1',
-                level: 1,
-              },
-            ],
-            items: [],
-          },
-        ],
-      };
-
-      const result = await service.syncStructures2(dtoIndicators);
-      expect(result).toEqual({
-        message: 'Sincronización de padres completada',
-      });
-      expect(managerMock.save).toHaveBeenCalled();
-      expect(managerMock.create).toHaveBeenCalled();
-      expect(managerMock.query).toHaveBeenCalled();
+      await service['syncGroupItemIndicators'](1, [], 'agreement1', manager);
+      expect(manager.createQueryBuilder().delete).toHaveBeenCalled();
+      expect(manager.createQueryBuilder().execute).toHaveBeenCalled();
     });
   });
 });

--- a/server/researchindicators/src/domain/entities/project_groups/entities/project_group.entity.ts
+++ b/server/researchindicators/src/domain/entities/project_groups/entities/project_group.entity.ts
@@ -16,6 +16,36 @@ export class ProjectGroup extends AuditableEntity {
   @Column({ name: 'level', type: 'int', nullable: false })
   level: number;
 
-  @Column({ name: 'agreement_id', type: 'varchar', nullable: false })
+  @Column({ name: 'agreement_id', type: 'text', nullable: false })
   agreement_id: string;
+
+  @Column({ name: 'custom_field_1', type: 'text', nullable: true })
+  custom_field_1: string;
+
+  @Column({ name: 'custom_field_2', type: 'text', nullable: true })
+  custom_field_2: string;
+
+  @Column({ name: 'custom_field_3', type: 'text', nullable: true })
+  custom_field_3: string;
+
+  @Column({ name: 'custom_field_4', type: 'text', nullable: true })
+  custom_field_4: string;
+
+  @Column({ name: 'custom_field_5', type: 'text', nullable: true })
+  custom_field_5: string;
+
+  @Column({ name: 'custom_field_6', type: 'text', nullable: true })
+  custom_field_6: string;
+
+  @Column({ name: 'custom_field_7', type: 'text', nullable: true })
+  custom_field_7: string;
+
+  @Column({ name: 'custom_field_8', type: 'text', nullable: true })
+  custom_field_8: string;
+
+  @Column({ name: 'custom_field_9', type: 'text', nullable: true })
+  custom_field_9: string;
+
+  @Column({ name: 'custom_field_10', type: 'text', nullable: true })
+  custom_field_10: string;
 }

--- a/server/researchindicators/src/domain/shared/utils/clean-custom-fields.ts
+++ b/server/researchindicators/src/domain/shared/utils/clean-custom-fields.ts
@@ -1,0 +1,7 @@
+export function cleanCustomFields(customFields: any) {
+  return Object.fromEntries(
+    Object.entries(customFields).filter(
+      ([, value]) => value !== null && value !== undefined,
+    ),
+  );
+}

--- a/server/researchindicators/src/domain/shared/utils/clean-custom-fields.ts
+++ b/server/researchindicators/src/domain/shared/utils/clean-custom-fields.ts
@@ -1,7 +1,0 @@
-export function cleanCustomFields(customFields: any) {
-  return Object.fromEntries(
-    Object.entries(customFields).filter(
-      ([, value]) => value !== null && value !== undefined,
-    ),
-  );
-}


### PR DESCRIPTION
This pull request introduces support for custom fields in the `groups_items` and `project_groups` tables, updates related DTOs and entities, and refactors corresponding unit tests to accommodate the new structure. The changes are primarily aimed at enabling more flexible data modeling by allowing up to ten custom fields per group item and project group, and updating the data transfer objects to handle these fields.

### Database and Entity Updates

* Added ten nullable `custom_field_*` columns to both the `groups_items` and `project_groups` tables via a new migration, enabling storage of custom field data. (`server/researchindicators/src/db/migrations/1756389433866-STARmvpCustomFields.ts`)
* Updated the `GroupItem` entity to include properties for the new custom fields, mapping each column to a corresponding attribute. (`server/researchindicators/src/domain/entities/groups_items/entities/groups_item.entity.ts`)

### DTO and Data Structure Refactoring

* Refactored the `StructureDto` and related DTOs to replace the prior flat `name_level_1` and `name_level_2` fields with a new `levels` array, where each level can have its own set of custom fields. Introduced `LevelDto`, `CustomFieldDto`, and `CustomValueDto` for more granular data modeling. (`server/researchindicators/src/domain/entities/groups_items/dto/group-item-action.dto.ts`)
* Updated `ParentItemDto` and `ChildItemDto` to support arrays of custom values, reflecting the new custom field structure. (`server/researchindicators/src/domain/entities/groups_items/dto/group-item-action.dto.ts`) [[1]](diffhunk://#diff-9f9da637b3234aac9ee5e09c442b31411a02f3b9d5ab6d74f5d3ab910a2306a7R75-R80) [[2]](diffhunk://#diff-9f9da637b3234aac9ee5e09c442b31411a02f3b9d5ab6d74f5d3ab910a2306a7L77-R123)

### Unit Test Updates

* Refactored controller and service tests to use the new `levels` array and custom field structure, replacing references to `name_level_1` and `name_level_2` with the updated format. This ensures tests validate the new data model and custom field handling. (`server/researchindicators/src/domain/entities/groups_items/groups_items.controller.spec.ts`, `server/researchindicators/src/domain/entities/groups_items/groups_items.service.spec.ts`) [[1]](diffhunk://#diff-3ea1eb2af34656711a3cf96dc63294e6d212f3dd82fbe127c080f5a983f019d2L45-R60) [[2]](diffhunk://#diff-3ea1eb2af34656711a3cf96dc63294e6d212f3dd82fbe127c080f5a983f019d2L64-R86) [[3]](diffhunk://#diff-3ea1eb2af34656711a3cf96dc63294e6d212f3dd82fbe127c080f5a983f019d2L82-R112) [[4]](diffhunk://#diff-3ea1eb2af34656711a3cf96dc63294e6d212f3dd82fbe127c080f5a983f019d2L126-R164) [[5]](diffhunk://#diff-ad6f162d82d16c9c76db6d75abe9ba5772cc691257f0ebaf32973806f433ab9fL24-R25)

These changes collectively make the system more extensible and ready for use cases requiring dynamic, user-defined fields on group items and project groups.