### PR TITLE
Ac 1069 us4 download oicr template with pre filled information back

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-cd client/research-indicators
-npm run lint
-npm run s-lint
-npm run test

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -3,11 +3,6 @@ export class ProjectDto {
   project_title: string;
 }
 
-export class TagDto {
-  tag_id: number;
-  tag_name: string;
-}
-
 export class LeverDto {
   lever_id: string;
   lever_short: string;
@@ -31,11 +26,12 @@ export class ResultMappedDto {
   main_project_id: string;
   main_project: string;
   other_projects: ProjectDto[];
-  tags: TagDto[];
+  tag_id: number | null;
+  tag_name: string | null;
   outcome_impact_statement: string;
-  main_lever_id: string | null;  // Puede ser null por LEFT JOIN
-  main_lever_short: string | null;  // Puede ser null por LEFT JOIN
-  main_lever_full: string | null;  // Puede ser null por LEFT JOIN
+  main_lever_id: string | null;
+  main_lever_short: string | null;
+  main_lever_full: string | null;
   other_levers: LeverDto[];
   geographic_scope: string;
   regions: RegionDto[];

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -19,6 +19,12 @@ export class CountryDto {
   country_name: string;
 }
 
+export class MainLeverDto {
+  main_lever_id: string;
+  main_lever: string;
+  main_lever_name: string;
+}
+
 export class ResultMappedDto {
   id: number;
   official_code: number;
@@ -29,9 +35,7 @@ export class ResultMappedDto {
   tag_id: number | null;
   tag_name: string | null;
   outcome_impact_statement: string;
-  main_lever_id: string | null;
-  main_lever_short: string | null;
-  main_lever_full: string | null;
+  main_levers: MainLeverDto[];
   other_levers: LeverDto[];
   geographic_scope: string;
   regions: RegionDto[];

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -1,0 +1,67 @@
+import { IsString, IsNumber, IsOptional, IsNotEmpty } from 'class-validator';
+
+export class ResponseOicrWordTemplateDto {
+  @IsString()
+  @IsNotEmpty()
+  result_code: string;
+
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  project_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  project_title: string;
+
+  @IsOptional()
+  @IsNumber()
+  tag_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  tagging?: string | null;
+
+  @IsOptional()
+  @IsString()
+  outcome_impact_statement?: string | null;
+
+  @IsOptional()
+  @IsNumber()
+  lever_id?: number | null;
+
+  @IsOptional()
+  @IsString()
+  lever?: string | null;
+
+  @IsOptional()
+  @IsString()
+  lever_name?: string | null;
+
+  @IsOptional()
+  @IsString()
+  geographic_scope?: string | null;
+
+  @IsOptional()
+  @IsString()
+  region_code?: string | null;
+
+  @IsOptional()
+  @IsString()
+  region_name?: string | null;
+
+  @IsOptional()
+  @IsString()
+  country_code?: string | null;
+
+  @IsOptional()
+  @IsString()
+  country_name?: string | null;
+
+  @IsOptional()
+  @IsString()
+  comment_geo_scope?: string | null;
+}

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -1,5 +1,3 @@
-import { IsString, IsNumber, IsOptional, IsNotEmpty } from 'class-validator';
-
 export class ProjectDto {
   project_id: string;
   project_title: string;

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -1,67 +1,46 @@
 import { IsString, IsNumber, IsOptional, IsNotEmpty } from 'class-validator';
 
-export class ResponseOicrWordTemplateDto {
-  @IsString()
-  @IsNotEmpty()
-  result_code: string;
-
-  @IsString()
-  @IsNotEmpty()
-  title: string;
-
-  @IsString()
-  @IsNotEmpty()
+export class ProjectDto {
   project_id: string;
-
-  @IsString()
-  @IsNotEmpty()
   project_title: string;
+}
 
-  @IsOptional()
-  @IsNumber()
-  tag_id?: number | null;
+export class TagDto {
+  tag_id: number;
+  tag_name: string;
+}
 
-  @IsOptional()
-  @IsString()
-  tagging?: string | null;
+export class LeverDto {
+  lever_id: string;
+  lever_short: string;
+  lever_full: string;
+}
 
-  @IsOptional()
-  @IsString()
-  outcome_impact_statement?: string | null;
+export class RegionDto {
+  region_code: string;
+  region_name: string;
+}
 
-  @IsOptional()
-  @IsNumber()
-  lever_id?: number | null;
+export class CountryDto {
+  country_code: string;
+  country_name: string;
+}
 
-  @IsOptional()
-  @IsString()
-  lever?: string | null;
-
-  @IsOptional()
-  @IsString()
-  lever_name?: string | null;
-
-  @IsOptional()
-  @IsString()
-  geographic_scope?: string | null;
-
-  @IsOptional()
-  @IsString()
-  region_code?: string | null;
-
-  @IsOptional()
-  @IsString()
-  region_name?: string | null;
-
-  @IsOptional()
-  @IsString()
-  country_code?: string | null;
-
-  @IsOptional()
-  @IsString()
-  country_name?: string | null;
-
-  @IsOptional()
-  @IsString()
-  comment_geo_scope?: string | null;
+export class ResultMappedDto {
+  id: number;
+  official_code: number;
+  title: string;
+  main_project_id: string;
+  main_project: string;
+  other_projects: ProjectDto[];
+  tags: TagDto[];
+  outcome_impact_statement: string;
+  main_lever_id: string | null;  // Puede ser null por LEFT JOIN
+  main_lever_short: string | null;  // Puede ser null por LEFT JOIN
+  main_lever_full: string | null;  // Puede ser null por LEFT JOIN
+  other_levers: LeverDto[];
+  geographic_scope: string;
+  regions: RegionDto[];
+  countries: CountryDto[];
+  geographic_scope_comments: string;
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -46,4 +46,46 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
     result.oicr_link = `${this.appConfig.ARI_CLIENT_HOST}/result/${result.result_code}/general-information`;
     return result;
   }
+
+  async getResultOicrDetailsByOfficialCode(resultOfficialCode: number) {
+    const query = `
+      SELECT 
+        r.result_official_code as result_code,
+        r.title,
+        ac.agreement_id as project_id,
+        ac.description as project_title,
+        t.id as tag_id,
+        t.name as tagging,
+        ro.outcome_impact_statement,
+        cl.id as lever_id,
+        cl.short_name as lever,
+        cl.full_name as lever_name,
+        cgs.name as geographic_scope,
+        cr.um49Code as region_code,
+        cr.name as region_name,
+        cc.isoAlpha2 as country_code,
+        cc.name as country_name,
+        r.comment_geo_scope
+      FROM results r
+      INNER JOIN result_oicrs ro ON ro.result_id = r.result_id 
+      INNER JOIN result_contracts rc ON rc.result_id = r.result_id 
+          AND rc.is_active = TRUE
+      INNER JOIN agresso_contracts ac ON ac.agreement_id = rc.contract_id 
+      LEFT JOIN result_levers rl ON rl.result_id = r.result_id 
+          AND rl.lever_role_id = 1
+      LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id 
+      LEFT JOIN result_tags rt on rt.result_id = r.result_id
+      LEFT JOIN tags t on t.id = rt.tag_id
+      LEFT JOIN clarisa_geo_scope cgs on cgs.code = r.geo_scope_id
+      LEFT JOIN result_regions rg on rg.result_id = r.result_id
+      LEFT JOIN clarisa_regions cr on cr.um49Code = rg.region_id
+      LEFT JOIN result_countries rco on rco.result_id = r.result_id
+      LEFT JOIN clarisa_countries cc on cc.isoAlpha2 = rco.isoAlpha2
+      WHERE r.result_official_code = ?
+        AND r.is_active = TRUE
+      LIMIT 1;
+    `;
+    const result = await this.query(query, [resultOfficialCode]);
+    return result?.[0] ?? null;
+  }
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -32,7 +32,7 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
                     INNER JOIN agresso_contracts ac ON ac.agreement_id = rc.contract_id 
                     LEFT JOIN result_levers rl ON rl.result_id = r.result_id 
                                                 AND rl.is_primary = TRUE
-                                                AND rl.lever_role_id = 1
+                                                AND rl.lever_role_id = 2
                     LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id 
                     LEFT JOIN result_users ru ON ru.result_id = r.result_id 
                                                 AND ru.is_active = TRUE
@@ -87,12 +87,12 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
       LEFT JOIN agresso_contracts ac 
         ON ac.agreement_id = rc.contract_id
       LEFT JOIN result_levers rl_main ON rl_main.result_id = r.result_id 
-        AND rl_main.lever_role_id = 1
+        AND rl_main.lever_role_id = 2
         AND rl_main.is_active = TRUE 
         AND rl_main.is_primary = 1
       LEFT JOIN clarisa_levers cl_main ON cl_main.id = rl_main.lever_id
       LEFT JOIN result_levers rl ON rl.result_id = r.result_id 
-        AND rl.lever_role_id = 1
+        AND rl.lever_role_id = 2
         AND rl.is_active = TRUE 
         AND rl.is_primary = 0
       LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id 

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -97,12 +97,15 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
         AND rl.is_primary = 0
       LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id 
       LEFT JOIN result_tags rt on rt.result_id = r.result_id
+        AND rt.is_active = TRUE
       LEFT JOIN tags t on t.id = rt.tag_id
         AND t.is_active = TRUE
       LEFT JOIN clarisa_geo_scope cgs on cgs.code = r.geo_scope_id
       LEFT JOIN result_regions rg on rg.result_id = r.result_id
+        AND rg.is_active = TRUE
       LEFT JOIN clarisa_regions cr on cr.um49Code = rg.region_id
       LEFT JOIN result_countries rco on rco.result_id = r.result_id
+        AND rco.is_active = TRUE
       LEFT JOIN clarisa_countries cc on cc.isoAlpha2 = rco.isoAlpha2
       WHERE r.result_id = ?
         AND r.is_active = TRUE;

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -58,7 +58,7 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
         ac.agreement_id as project_id,
         ac.description as project_title,
         t.id as tag_id,
-        t.name as tagging,
+        t.name as tag_name,
         ro.outcome_impact_statement,
         cl_main.id as main_lever_id,
         cl_main.short_name as main_lever,
@@ -98,6 +98,7 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
       LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id 
       LEFT JOIN result_tags rt on rt.result_id = r.result_id
       LEFT JOIN tags t on t.id = rt.tag_id
+        AND t.is_active = TRUE
       LEFT JOIN clarisa_geo_scope cgs on cgs.code = r.geo_scope_id
       LEFT JOIN result_regions rg on rg.result_id = r.result_id
       LEFT JOIN clarisa_regions cr on cr.um49Code = rg.region_id

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -47,16 +47,22 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
     return result;
   }
 
-  async getResultOicrDetailsByOfficialCode(resultOfficialCode: number) {
+  async getResultOicrDetailsByOfficialCode(resultId: number) {
     const query = `
-      SELECT 
+      SELECT
+        r.result_id,
         r.result_official_code as result_code,
         r.title,
+        ac_main.agreement_id AS main_project_id,
+        ac_main.description AS main_project_title,
         ac.agreement_id as project_id,
         ac.description as project_title,
         t.id as tag_id,
         t.name as tagging,
         ro.outcome_impact_statement,
+        cl_main.id as main_lever_id,
+        cl_main.short_name as main_lever,
+        cl_main.full_name as main_lever_name,
         cl.id as lever_id,
         cl.short_name as lever,
         cl.full_name as lever_name,
@@ -67,12 +73,28 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
         cc.name as country_name,
         r.comment_geo_scope
       FROM results r
-      INNER JOIN result_oicrs ro ON ro.result_id = r.result_id 
-      INNER JOIN result_contracts rc ON rc.result_id = r.result_id 
-          AND rc.is_active = TRUE
-      INNER JOIN agresso_contracts ac ON ac.agreement_id = rc.contract_id 
+      INNER JOIN result_oicrs ro ON ro.result_id = r.result_id
+      INNER JOIN result_contracts rc_main 
+        ON rc_main.result_id = r.result_id 
+        AND rc_main.is_active = TRUE 
+        AND rc_main.is_primary = 1
+      INNER JOIN agresso_contracts ac_main 
+      ON ac_main.agreement_id = rc_main.contract_id
+      LEFT JOIN result_contracts rc 
+        ON rc.result_id = r.result_id 
+        AND rc.is_active = TRUE 
+        AND rc.is_primary = 0
+      LEFT JOIN agresso_contracts ac 
+        ON ac.agreement_id = rc.contract_id
+      LEFT JOIN result_levers rl_main ON rl_main.result_id = r.result_id 
+        AND rl_main.lever_role_id = 1
+        AND rl_main.is_active = TRUE 
+        AND rl_main.is_primary = 1
+      LEFT JOIN clarisa_levers cl_main ON cl_main.id = rl_main.lever_id
       LEFT JOIN result_levers rl ON rl.result_id = r.result_id 
-          AND rl.lever_role_id = 1
+        AND rl.lever_role_id = 1
+        AND rl.is_active = TRUE 
+        AND rl.is_primary = 0
       LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id 
       LEFT JOIN result_tags rt on rt.result_id = r.result_id
       LEFT JOIN tags t on t.id = rt.tag_id
@@ -81,11 +103,9 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
       LEFT JOIN clarisa_regions cr on cr.um49Code = rg.region_id
       LEFT JOIN result_countries rco on rco.result_id = r.result_id
       LEFT JOIN clarisa_countries cc on cc.isoAlpha2 = rco.isoAlpha2
-      WHERE r.result_official_code = ?
-        AND r.is_active = TRUE
-      LIMIT 1;
+      WHERE r.result_id = ?
+        AND r.is_active = TRUE;
     `;
-    const result = await this.query(query, [resultOfficialCode]);
-    return result?.[0] ?? null;
+    return await this.query(query, [resultId]);
   }
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.controller.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.controller.ts
@@ -3,14 +3,13 @@ import {
   Controller,
   Get,
   HttpStatus,
-  Param,
   Patch,
   Post,
   UseInterceptors,
 } from '@nestjs/common';
 import { ResultOicrService } from './result-oicr.service';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
-import { ApiBearerAuth, ApiBody, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { GetResultVersion } from '../../shared/decorators/versioning.decorator';
 import { RESULT_CODE, ResultsUtil } from '../../shared/utils/results.util';
 import { CreateResultOicrDto } from './dto/create-result-oicr.dto';

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.controller.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.controller.ts
@@ -68,9 +68,9 @@ export class ResultOicrController {
     );
   }
 
-  @Get(`ejemplo/${RESULT_CODE}`)
+  @Get(`details/${RESULT_CODE}`)
   @GetResultVersion()
-  async getWordTemplate(@Query('step', ParseIntPipe) step: number) {
+  async getWordTemplate() {
     return this.resultOicrService
     .getResultOicrDetailsByOfficialCode(this.resultUtil.resultId)
     .then((result) =>

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.controller.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpStatus,
+  Param,
   ParseIntPipe,
   Patch,
   Post,
@@ -11,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { ResultOicrService } from './result-oicr.service';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
-import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiParam, ApiTags } from '@nestjs/swagger';
 import { GetResultVersion } from '../../shared/decorators/versioning.decorator';
 import { RESULT_CODE, ResultsUtil } from '../../shared/utils/results.util';
 import { CreateStepsOicrDto } from './dto/create-steps-oicr.dto';
@@ -71,4 +72,19 @@ export class ResultOicrController {
       }),
     );
   }
+
+  @Get(`ejemplo/${RESULT_CODE}`)
+  @GetResultVersion()
+  async getWordTemplate(@Query('step', ParseIntPipe) step: number) {
+    return this.resultOicrService
+    .getResultOicrDetailsByOfficialCode(this.resultUtil.resultId)
+    .then((result) =>
+      ResponseUtils.format({
+        data: result,
+        description: 'Result OICR word template retrieved successfully',
+        status: HttpStatus.OK,
+      }),
+    );
+  }
+
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.spec.ts
@@ -1457,7 +1457,7 @@ describe('ResultOicrService', () => {
   });
 
   describe('getResultOicrDetailsByOfficialCode', () => {
-    it('debería retornar null si no hay resultados', async () => {
+    it('should return null if there are no results', async () => {
       mockResultOicrRepository.getResultOicrDetailsByOfficialCode.mockResolvedValue([]);
 
       const result = await service.getResultOicrDetailsByOfficialCode(1);
@@ -1465,32 +1465,32 @@ describe('ResultOicrService', () => {
       expect(result).toBeNull();
     });
 
-    it('debería mapear correctamente un resultado con todos los campos', async () => {
+    it('should correctly map a result with all fields', async () => {
       const mockRawResults = [
-        {
-          result_id: 1,
-          result_code: 'OICR-001',
-          title: 'Título del resultado',
-          main_project_id: 'P1',
-          main_project_title: 'Proyecto principal',
-          project_id: 'P2',
-          project_title: 'Proyecto secundario',
-          tag_id: 10,
-          tag_name: 'Tag de prueba',
-          outcome_impact_statement: 'Impacto esperado',
-          main_lever_id: 'ML1',
-          main_lever: 'Lever principal',
-          main_lever_name: 'Nombre lever principal',
-          lever_id: 'L1',
-          lever: 'Lever corto',
-          lever_name: 'Lever largo',
-          geographic_scope: 'Global',
-          region_code: 'R1',
-          region_name: 'Región de prueba',
-          country_code: 'C1',
-          country_name: 'País de prueba',
-          comment_geo_scope: 'Comentario de alcance'
-        }
+      {
+        result_id: 1,
+        result_code: 'OICR-001',
+        title: 'Result Title',
+        main_project_id: 'P1',
+        main_project_title: 'Main Project',
+        project_id: 'P2',
+        project_title: 'Secondary Project',
+        tag_id: 10,
+        tag_name: 'Test Tag',
+        outcome_impact_statement: 'Expected Impact',
+        main_lever_id: 'ML1',
+        main_lever: 'Main Lever',
+        main_lever_name: 'Main Lever Name',
+        lever_id: 'L1',
+        lever: 'Short Lever',
+        lever_name: 'Long Lever',
+        geographic_scope: 'Global',
+        region_code: 'R1',
+        region_name: 'Test Region',
+        country_code: 'C1',
+        country_name: 'Test Country',
+        comment_geo_scope: 'Scope Comment'
+      }
       ];
 
       mockResultOicrRepository.getResultOicrDetailsByOfficialCode.mockResolvedValue(mockRawResults);
@@ -1498,84 +1498,84 @@ describe('ResultOicrService', () => {
       const result = await service.getResultOicrDetailsByOfficialCode(1);
 
       expect(result).toEqual({
-        id: 1,
-        official_code: 'OICR-001',
-        title: 'Título del resultado',
-        main_project_id: 'P1',
-        main_project: 'Proyecto principal',
-        other_projects: [
-          { project_id: 'P2', project_title: 'Proyecto secundario' }
-        ],
-        tag_id: 10,
-        tag_name: 'Tag de prueba',
-        outcome_impact_statement: 'Impacto esperado',
-        main_levers: [
-          { main_lever_id: 'ML1', main_lever: 'Lever principal', main_lever_name: 'Nombre lever principal' }
-        ],
-        other_levers: [
-          { lever_id: 'L1', lever_short: 'Lever corto', lever_full: 'Lever largo' }
-        ],
-        geographic_scope: 'Global',
-        regions: [
-          { region_code: 'R1', region_name: 'Región de prueba' }
-        ],
-        countries: [
-          { country_code: 'C1', country_name: 'País de prueba' }
-        ],
-        geographic_scope_comments: 'Comentario de alcance'
+      id: 1,
+      official_code: 'OICR-001',
+      title: 'Result Title',
+      main_project_id: 'P1',
+      main_project: 'Main Project',
+      other_projects: [
+        { project_id: 'P2', project_title: 'Secondary Project' }
+      ],
+      tag_id: 10,
+      tag_name: 'Test Tag',
+      outcome_impact_statement: 'Expected Impact',
+      main_levers: [
+        { main_lever_id: 'ML1', main_lever: 'Main Lever', main_lever_name: 'Main Lever Name' }
+      ],
+      other_levers: [
+        { lever_id: 'L1', lever_short: 'Short Lever', lever_full: 'Long Lever' }
+      ],
+      geographic_scope: 'Global',
+      regions: [
+        { region_code: 'R1', region_name: 'Test Region' }
+      ],
+      countries: [
+        { country_code: 'C1', country_name: 'Test Country' }
+      ],
+      geographic_scope_comments: 'Scope Comment'
       });
     });
 
-    it('debería mapear múltiples proyectos, levers, regiones y países sin duplicados', async () => {
+    it('should map multiple projects, levers, regions, and countries without duplicates', async () => {
       const mockRawResults = [
-        {
-          result_id: 2,
-          result_code: 'OICR-002',
-          title: 'Otro resultado',
-          main_project_id: 'P10',
-          main_project_title: 'Proyecto X',
-          project_id: 'P11',
-          project_title: 'Proyecto Y',
-          tag_id: null,
-          tag_name: null,
-          outcome_impact_statement: null,
-          main_lever_id: 'ML2',
-          main_lever: 'Lever P',
-          main_lever_name: 'Lever Principal P',
-          lever_id: 'L2',
-          lever: 'Corto',
-          lever_name: 'Largo',
-          geographic_scope: 'Regional',
-          region_code: 'R2',
-          region_name: 'Región Y',
-          country_code: 'C2',
-          country_name: 'País Y',
-          comment_geo_scope: null
-        },
-        {
-          result_id: 2,
-          result_code: 'OICR-002',
-          title: 'Otro resultado',
-          main_project_id: 'P10',
-          main_project_title: 'Proyecto X',
-          project_id: 'P12',
-          project_title: 'Proyecto Z',
-          tag_id: null,
-          tag_name: null,
-          outcome_impact_statement: null,
-          main_lever_id: 'ML2',
-          main_lever: 'Lever P',
-          main_lever_name: 'Lever Principal P',
-          lever_id: 'L3',
-          lever: 'Otro',
-          lever_name: 'Otro largo',
-          geographic_scope: 'Regional',
-          region_code: 'R3',
-          region_name: 'Región Z',
-          country_code: 'C3',
-          country_name: 'País Z',
-          comment_geo_scope: null
-        }
+      {
+        result_id: 2,
+        result_code: 'OICR-002',
+        title: 'Another result',
+        main_project_id: 'P10',
+        main_project_title: 'Project X',
+        project_id: 'P11',
+        project_title: 'Project Y',
+        tag_id: null,
+        tag_name: null,
+        outcome_impact_statement: null,
+        main_lever_id: 'ML2',
+        main_lever: 'Lever P',
+        main_lever_name: 'Main Lever P',
+        lever_id: 'L2',
+        lever: 'Short',
+        lever_name: 'Long',
+        geographic_scope: 'Regional',
+        region_code: 'R2',
+        region_name: 'Region Y',
+        country_code: 'C2',
+        country_name: 'Country Y',
+        comment_geo_scope: null
+      },
+      {
+        result_id: 2,
+        result_code: 'OICR-002',
+        title: 'Another result',
+        main_project_id: 'P10',
+        main_project_title: 'Project X',
+        project_id: 'P12',
+        project_title: 'Project Z',
+        tag_id: null,
+        tag_name: null,
+        outcome_impact_statement: null,
+        main_lever_id: 'ML2',
+        main_lever: 'Lever P',
+        main_lever_name: 'Main Lever P',
+        lever_id: 'L3',
+        lever: 'Other',
+        lever_name: 'Other long',
+        geographic_scope: 'Regional',
+        region_code: 'R3',
+        region_name: 'Region Z',
+        country_code: 'C3',
+        country_name: 'Country Z',
+        comment_geo_scope: null
+      }
       ];
 
       mockResultOicrRepository.getResultOicrDetailsByOfficialCode.mockResolvedValue(mockRawResults);
@@ -1587,7 +1587,7 @@ describe('ResultOicrService', () => {
       expect(result.other_levers).toHaveLength(2);
       expect(result.regions).toHaveLength(2);
       expect(result.countries).toHaveLength(2);
-    });  
+    });
   });
 
 });

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -37,7 +37,7 @@ import { TempExternalOicrsService } from '../temp_external_oicrs/temp_external_o
 import { UpdateOicrDto } from './dto/update-oicr.dto';
 import { TempResultExternalOicr } from '../temp_external_oicrs/entities/temp_result_external_oicr.entity';
 import { isEmpty } from '../../shared/utils/object.utils';
-import { ResponseOicrWordTemplateDto } from './dto/response-oicr-word-template.dto';
+import { CountryDto, LeverDto, ProjectDto, RegionDto, ResultMappedDto, TagDto } from './dto/response-oicr-word-template.dto';
 
 @Injectable()
 export class ResultOicrService {
@@ -352,7 +352,76 @@ export class ResultOicrService {
     };
   }
 
-  async getResultOicrDetailsByOfficialCode(resultId: number): Promise<ResponseOicrWordTemplateDto> {
-    return this.mainRepo.getResultOicrDetailsByOfficialCode(resultId);
+  async getResultOicrDetailsByOfficialCode(resultId: number): Promise<ResultMappedDto> {
+    const rawResults = await this.mainRepo.getResultOicrDetailsByOfficialCode(resultId);
+
+    if (!rawResults || rawResults.length === 0) {
+      return null;
+    }
+
+    const firstRow = rawResults[0];
+    
+    const projectsMap = new Map<string, ProjectDto>();
+    const tagsMap = new Map<number, TagDto>();
+    const leversMap = new Map<string, LeverDto>();
+    const regionsMap = new Map<string, RegionDto>();
+    const countriesMap = new Map<string, CountryDto>();
+
+    rawResults.forEach(row => {
+      if (row.project_id && row.project_title) {
+        projectsMap.set(row.project_id, {
+          project_id: row.project_id,
+          project_title: row.project_title
+        });
+      }
+
+      if (row.tag_id && row.tagging) {
+        tagsMap.set(row.tag_id, {
+          tag_id: row.tag_id,
+          tag_name: row.tagging
+        });
+      }
+
+      if (row.lever_id && row.lever) {
+        leversMap.set(row.lever_id, {
+          lever_id: row.lever_id,
+          lever_short: row.lever,
+          lever_full: row.lever_name
+        });
+      }
+
+      if (row.region_code && row.region_name) {
+        regionsMap.set(row.region_code, {
+          region_code: row.region_code,
+          region_name: row.region_name
+        });
+      }
+
+      if (row.country_code && row.country_name) {
+        countriesMap.set(row.country_code, {
+          country_code: row.country_code,
+          country_name: row.country_name
+        });
+      }
+    });
+
+    return {
+      id: firstRow.result_id,
+      official_code: firstRow.result_code,
+      title: firstRow.title,
+      main_project_id: firstRow.main_project_id,
+      main_project: firstRow.main_project_title,
+      other_projects: Array.from(projectsMap.values()),
+      tags: Array.from(tagsMap.values()),
+      outcome_impact_statement: firstRow.outcome_impact_statement,
+      main_lever_id: firstRow.main_lever_id,
+      main_lever_short: firstRow.main_lever,
+      main_lever_full: firstRow.main_lever_name,
+      other_levers: Array.from(leversMap.values()),
+      geographic_scope: firstRow.geographic_scope,
+      regions: Array.from(regionsMap.values()),
+      countries: Array.from(countriesMap.values()),
+      geographic_scope_comments: firstRow.comment_geo_scope
+    };
   }
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -35,6 +35,7 @@ import { AppConfig } from '../../shared/utils/app-config.util';
 import { TemplateService } from '../../shared/auxiliar/template/template.service';
 import { TemplateEnum } from '../../shared/auxiliar/template/enum/template.enum';
 import { ResultOicrRepository } from './repositories/result-oicr.repository';
+import { ResponseOicrWordTemplateDto } from './dto/response-oicr-word-template.dto';
 
 @Injectable()
 export class ResultOicrService {
@@ -273,5 +274,9 @@ export class ResultOicrService {
       primary_lever: allLevers.filter((lever) => lever.is_primary),
       contributor_lever: allLevers.filter((lever) => !lever.is_primary),
     };
+  }
+
+  async getResultOicrDetailsByOfficialCode(resultId: number): Promise<ResponseOicrWordTemplateDto> {
+    return this.mainRepo.getResultOicrDetailsByOfficialCode(resultId);
   }
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -37,7 +37,7 @@ import { TempExternalOicrsService } from '../temp_external_oicrs/temp_external_o
 import { UpdateOicrDto } from './dto/update-oicr.dto';
 import { TempResultExternalOicr } from '../temp_external_oicrs/entities/temp_result_external_oicr.entity';
 import { isEmpty } from '../../shared/utils/object.utils';
-import { CountryDto, LeverDto, ProjectDto, RegionDto, ResultMappedDto, TagDto } from './dto/response-oicr-word-template.dto';
+import { CountryDto, LeverDto, ProjectDto, RegionDto, ResultMappedDto} from './dto/response-oicr-word-template.dto';
 
 @Injectable()
 export class ResultOicrService {
@@ -362,7 +362,6 @@ export class ResultOicrService {
     const firstRow = rawResults[0];
     
     const projectsMap = new Map<string, ProjectDto>();
-    const tagsMap = new Map<number, TagDto>();
     const leversMap = new Map<string, LeverDto>();
     const regionsMap = new Map<string, RegionDto>();
     const countriesMap = new Map<string, CountryDto>();
@@ -372,13 +371,6 @@ export class ResultOicrService {
         projectsMap.set(row.project_id, {
           project_id: row.project_id,
           project_title: row.project_title
-        });
-      }
-
-      if (row.tag_id && row.tagging) {
-        tagsMap.set(row.tag_id, {
-          tag_id: row.tag_id,
-          tag_name: row.tagging
         });
       }
 
@@ -412,7 +404,8 @@ export class ResultOicrService {
       main_project_id: firstRow.main_project_id,
       main_project: firstRow.main_project_title,
       other_projects: Array.from(projectsMap.values()),
-      tags: Array.from(tagsMap.values()),
+      tag_id: firstRow.tag_id,
+      tag_name: firstRow.tag_name,
       outcome_impact_statement: firstRow.outcome_impact_statement,
       main_lever_id: firstRow.main_lever_id,
       main_lever_short: firstRow.main_lever,

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -37,7 +37,7 @@ import { TempExternalOicrsService } from '../temp_external_oicrs/temp_external_o
 import { UpdateOicrDto } from './dto/update-oicr.dto';
 import { TempResultExternalOicr } from '../temp_external_oicrs/entities/temp_result_external_oicr.entity';
 import { isEmpty } from '../../shared/utils/object.utils';
-import { CountryDto, LeverDto, ProjectDto, RegionDto, ResultMappedDto} from './dto/response-oicr-word-template.dto';
+import { CountryDto, LeverDto, MainLeverDto, ProjectDto, RegionDto, ResultMappedDto} from './dto/response-oicr-word-template.dto';
 
 @Injectable()
 export class ResultOicrService {
@@ -365,12 +365,21 @@ export class ResultOicrService {
     const leversMap = new Map<string, LeverDto>();
     const regionsMap = new Map<string, RegionDto>();
     const countriesMap = new Map<string, CountryDto>();
+    const mainLeversMap = new Map<string, MainLeverDto>();
 
     rawResults.forEach(row => {
       if (row.project_id && row.project_title) {
         projectsMap.set(row.project_id, {
           project_id: row.project_id,
           project_title: row.project_title
+        });
+      }
+
+      if (row.main_lever_id && row.main_lever) {
+        mainLeversMap.set(row.main_lever_id, {
+          main_lever_id: row.main_lever_id,
+          main_lever: row.main_lever,
+          main_lever_name: row.main_lever_name
         });
       }
 
@@ -407,9 +416,7 @@ export class ResultOicrService {
       tag_id: firstRow.tag_id,
       tag_name: firstRow.tag_name,
       outcome_impact_statement: firstRow.outcome_impact_statement,
-      main_lever_id: firstRow.main_lever_id,
-      main_lever_short: firstRow.main_lever,
-      main_lever_full: firstRow.main_lever_name,
+      main_levers: Array.from(mainLeversMap.values()),
       other_levers: Array.from(leversMap.values()),
       geographic_scope: firstRow.geographic_scope,
       regions: Array.from(regionsMap.values()),


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve detailed OICR result data in a word template format, along with supporting DTOs and logic for mapping and aggregating related entities. The changes include backend controller, service, and repository updates, as well as the removal of client-side pre-commit hooks.

**Backend feature: OICR word template details endpoint**
* Added new DTOs (`ProjectDto`, `LeverDto`, `RegionDto`, `CountryDto`, `MainLeverDto`, `ResultMappedDto`) in `response-oicr-word-template.dto.ts` to structure word template data for OICR results.
* Implemented the `getResultOicrDetailsByOfficialCode` method in `ResultOicrRepository` to fetch and join all necessary OICR-related data from multiple tables.
* Added the `getResultOicrDetailsByOfficialCode` method in `ResultOicrService` to aggregate, map, and deduplicate related entities from the raw query results into the new DTO format.
* Introduced a new controller endpoint `/details/:resultCode` in `ResultOicrController` to expose the word template data via HTTP GET.

**Code maintenance**
* Removed client-side linting and testing commands from the `.husky/pre-commit` hook, likely to streamline development workflow or shift responsibility elsewhere.