### PR TITLE
♻️ refactor(docker): update production Dockerfile to copy 'go' directory to the correct path

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -60,7 +60,7 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
-COPY --from=build /app/src/go ./src/go
+COPY --from=build /app/src/go ./dist/src/go
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
This pull request makes a small but important change to the Dockerfile for the `researchindicators` server. The Go source files are now copied into the `dist` directory instead of the root `src` directory during the Docker image build process. This helps keep all distributable files organized under `dist`.

- Docker build process improvement:
  * In `server/researchindicators/Dockerfile`, changed the destination of the Go source files from `./src/go` to `./dist/src/go` to better organize build artifacts.