### PR TITLE
chore(docker): optimize Dockerfile for improved build efficiency

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -60,7 +60,7 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
-COPY --from=build /app/src/go ./dist/src/go
+COPY --from=build /app/src/go ./src/go
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
This pull request makes a small adjustment to the Docker build process for the `researchindicators` service. The change updates the destination directory for the Go source files when copying them into the Docker image.

- Changed the destination of the Go source files from `./dist/src/go` to `./src/go` in the `Dockerfile`, ensuring the Go files are placed in the correct location in the final image.