### PR TITLE
chore(docker): update Dockerfile for improved build process

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -62,6 +62,9 @@ COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/src/go ./src/go
 
+# Ensure Go helper binaries are executable
+RUN chmod +x /app/src/go/bin/generate_excel
+
 # Switch to non-root user
 USER appuser
 


### PR DESCRIPTION
This pull request makes a minor improvement to the Dockerfile for the research indicators server. The change ensures that the Go helper binary `generate_excel` is executable within the container.

* Dockerfile improvement:
  * Added a `chmod +x` command to make `/app/src/go/bin/generate_excel` executable in the Docker image.