### PR TITLE
✨ feat(docker): add Go build stage and integrate generate_excel binary into development and production stages

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -1,3 +1,15 @@
+#################### GO BUILD STAGE ####################
+FROM golang:1.22-alpine AS go-build
+
+WORKDIR /workspace
+
+COPY src/go/go.mod src/go/go.sum ./
+RUN go mod download
+
+COPY src/go/ ./
+RUN mkdir -p bin && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/generate_excel .
+
+
 #################### BASE STAGE ####################
 FROM node:20.13.1-alpine AS base
 
@@ -16,6 +28,8 @@ RUN npm install  --ignore-scripts
 
 # Copy source code and config files
 COPY src ./src
+RUN rm -f ./src/go/bin/generate_excel*
+COPY --from=go-build /workspace/bin/generate_excel ./src/go/bin/generate_excel
 COPY tsconfig*.json ./
 COPY nest-cli.json ./
 COPY eslint.config.mjs ./
@@ -38,6 +52,8 @@ RUN npm ci --only=production --ignore-scripts
 
 # Copy source code and config files
 COPY src ./src
+RUN rm -f ./src/go/bin/generate_excel*
+COPY --from=go-build /workspace/bin/generate_excel ./src/go/bin/generate_excel
 COPY tsconfig*.json ./
 COPY nest-cli.json ./
 COPY package*.json ./


### PR DESCRIPTION
This pull request updates the `server/researchindicators/Dockerfile` to add a multi-stage build for compiling a Go binary and ensuring the correct binary is included in the final image. The main improvements are the introduction of a Go build stage and explicit management of the Go binary during the Docker build process.

**Dockerfile build process improvements:**

* Added a new build stage (`go-build`) using `golang:1.22-alpine` to compile the Go binary `generate_excel` from the source in `src/go/`, ensuring dependencies are downloaded and the binary is built for Linux/amd64.
* In the base stage, removed any existing `generate_excel` binaries from `./src/go/bin/` and copied the newly built binary from the `go-build` stage into the correct location, ensuring the image always contains the latest build. [[1]](diffhunk://#diff-589380f2b3efdc9448c17bd98672d556b5207bc14a2e1d32c6705dcd05d88811R31-R32) [[2]](diffhunk://#diff-589380f2b3efdc9448c17bd98672d556b5207bc14a2e1d32c6705dcd05d88811R55-R56)