### PR TITLE
♻️ refactor(docker): update Go build stage to use golang:1.26-alpine

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -1,5 +1,5 @@
 #################### GO BUILD STAGE ####################
-FROM golang:1.22-alpine AS go-build
+FROM golang:1.26-alpine AS go-build
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This pull request updates the Go version used in the `server/researchindicators/Dockerfile` to ensure compatibility with newer features and security updates.

Dependency update:

* Upgraded the Go base image from `golang:1.22-alpine` to `golang:1.26-alpine` in the Dockerfile.