### PR TITLE
chore(docker): update Dockerfile for consistency and maintainability

### DIFF
--- a/server/researchindicators/Dockerfile
+++ b/server/researchindicators/Dockerfile
@@ -1,5 +1,5 @@
 #################### GO BUILD STAGE ####################
-FROM golang:1.26-alpine AS go-build
+FROM golang:1.25-alpine AS go-build
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This pull request makes a minor change to the Go build stage in the `server/researchindicators/Dockerfile`, downgrading the Go version from 1.26 to 1.25.