### PR TITLE
Ac 1174 innovations add a new field for readiness explanation

### DIFF
--- a/server/researchindicators/src/db/migrations/1758035765432-InnovationReadinessExplanation.ts
+++ b/server/researchindicators/src/db/migrations/1758035765432-InnovationReadinessExplanation.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InnovationReadinessExplanation1758035765432 implements MigrationInterface {
+    name = 'InnovationReadinessExplanation1758035765432'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` ADD \`innovation_readiness_explanation\` text NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` DROP COLUMN \`innovation_readiness_explanation\``);
+    }
+
+}

--- a/server/researchindicators/src/db/migrations/1758039230848-AddInnovationReadinessExplanationCheck.ts
+++ b/server/researchindicators/src/db/migrations/1758039230848-AddInnovationReadinessExplanationCheck.ts
@@ -1,0 +1,222 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddInnovationReadinessExplanationCheck1758039230848 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        DROP FUNCTION IF EXISTS \`innovation_dev_validation\`;
+        `);
+
+        await queryRunner.query(`
+        CREATE FUNCTION \`innovation_dev_validation\`(result_code BIGINT) RETURNS tinyint(1)
+        READS SQL DATA
+        BEGIN
+            DECLARE commonFields BOOLEAN DEFAULT FALSE;
+            DECLARE anticipatedUserId BIGINT DEFAULT NULL;
+            DECLARE tempSecondFields BOOLEAN DEFAULT FALSE;
+            DECLARE tempActors INT DEFAULT NULL;
+            DECLARE tempFullActors INT DEFAULT NULL;
+            DECLARE tempInstitutionType INT DEFAULT NULL;
+            DECLARE tempFullInstitutionType INT DEFAULT NULL;
+            DECLARE knowledgeSharing BOOLEAN DEFAULT FALSE;
+            DECLARE readinessLevel BIGINT DEFAULT NULL;
+
+            SELECT 
+                (valid_text(rid.short_title) AND
+                rid.innovation_nature_id IS NOT NULL AND
+                rid.innovation_type_id IS NOT NULL AND
+                rid.innovation_readiness_id IS NOT NULL AND
+                rid.innovation_readiness_explanation IS NOT NULL AND
+                IF(rid.is_new_or_improved_variety = TRUE, rid.new_or_improved_varieties_count > 0, TRUE) AND
+                rid.anticipated_users_id IS NOT NULL),
+                rid.anticipated_users_id,
+                (valid_text(rid.expected_outcome) AND
+                valid_text(rid.intended_beneficiaries_description)),
+                IF(rid.is_knowledge_sharing = TRUE AND rid.is_knowledge_sharing IS NOT NULL, 
+                    IF(rid.dissemination_qualification_id IS NOT NULL AND rid.dissemination_qualification_id = 2,
+                        valid_text(rid.tool_useful_context) 
+                        AND valid_text(rid.results_achieved_expected)
+                        AND rid.tool_function_id IS NOT NULL
+                        AND IF(rid.is_used_beyond_original_context = TRUE,
+                            valid_text(rid.adoption_adaptation_context),
+                            IF(rid.is_used_beyond_original_context IS NULL, FALSE, TRUE)
+                        ),  
+                        IF(rid.dissemination_qualification_id IS NULL, FALSE, TRUE)
+                    ), 
+                    IF(rid.is_knowledge_sharing IS NULL, FALSE, TRUE)
+                ),
+                cirl.level
+            INTO
+                commonFields,
+                anticipatedUserId,
+                tempSecondFields,
+                knowledgeSharing,
+                readinessLevel
+            FROM results r 
+            INNER JOIN result_innovation_dev rid ON r.result_id = rid.result_id 
+            LEFT JOIN clarisa_innovation_readiness_levels cirl ON cirl.id = rid.innovation_readiness_id
+            WHERE r.result_id = result_code
+            AND r.is_active = TRUE
+            LIMIT 1;
+            
+            SELECT COUNT(ra.result_actors_id)
+            INTO tempFullActors
+            FROM result_actors ra 
+            WHERE ra.result_id = result_code
+            AND ra.is_active = TRUE;
+            
+            SELECT IFNULL(
+                    SUM(
+                        CASE
+                            WHEN ra.actor_type_id = 5 THEN ra.actor_type_custom_name IS NOT NULL
+                            ELSE ra.actor_type_id IS NOT NULL
+                        END
+                    ), FALSE)
+            INTO tempActors
+            FROM result_actors ra 
+            WHERE ra.result_id = result_code
+            AND ra.is_active = TRUE;
+            
+            SELECT IFNULL(SUM(CASE 
+                WHEN rit.is_organization_known = TRUE THEN rit.institution_id IS NOT NULL
+                ELSE (CASE
+                    WHEN rit.institution_type_id = 78 THEN rit.institution_type_custom_name IS NOT NULL
+                    WHEN (rit.institution_type_id != 78 AND rit.institution_type_id IS NOT NULL) THEN CASE 
+                        WHEN (SELECT COUNT(cit.code) FROM clarisa_institution_types cit WHERE cit.parent_code = rit.institution_type_id) > 0 THEN rit.sub_institution_type_id IS NOT NULL
+                        ELSE rit.institution_type_id IS NOT NULL
+                        END
+                    ELSE FALSE
+                    END)
+                END), FALSE)
+            INTO tempInstitutionType
+            FROM result_institution_types rit 
+            WHERE rit.result_id = result_code
+            AND rit.is_active = TRUE;
+            
+            SELECT count(rit.result_institution_type_id)
+            INTO tempFullInstitutionType
+            FROM result_institution_types rit 
+            WHERE rit.result_id = result_code
+            AND rit.is_active = TRUE;
+            
+            RETURN IF(anticipatedUserId = 1 OR anticipatedUserId IS NULL, TRUE, (tempInstitutionType = tempFullInstitutionType) AND 
+                (tempInstitutionType > 0) AND
+                (tempFullActors = tempActors) AND 
+                (tempActors > 0) AND
+                tempSecondFields)
+                AND commonFields  
+                AND IF(readinessLevel >= 7, knowledgeSharing, TRUE);
+        END
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP FUNCTION IF EXISTS \`innovation_dev_validation\`;
+        `);
+
+        await queryRunner.query(`
+            CREATE FUNCTION \`innovation_dev_validation\`(result_code BIGINT) RETURNS tinyint(1)
+            READS SQL DATA
+            BEGIN
+                DECLARE commonFields BOOLEAN DEFAULT FALSE;
+                DECLARE anticipatedUserId BIGINT DEFAULT NULL;
+                DECLARE tempSecondFields BOOLEAN DEFAULT FALSE;
+                DECLARE tempActors INT DEFAULT NULL;
+                DECLARE tempFullActors INT DEFAULT NULL;
+                DECLARE tempInstitutionType INT DEFAULT NULL;
+                DECLARE tempFullInstitutionType INT DEFAULT NULL;
+                DECLARE knowledgeSharing BOOLEAN DEFAULT FALSE;
+                DECLARE readinessLevel BIGINT DEFAULT NULL;
+
+                SELECT 
+                    (valid_text(rid.short_title) AND
+                    rid.innovation_nature_id IS NOT NULL AND
+                    rid.innovation_type_id IS NOT NULL AND
+                    rid.innovation_readiness_id IS NOT NULL AND
+                    IF(rid.is_new_or_improved_variety = TRUE, rid.new_or_improved_varieties_count > 0, TRUE) AND
+                    rid.anticipated_users_id IS NOT NULL),
+                    rid.anticipated_users_id,
+                    (valid_text(rid.expected_outcome) AND
+                    valid_text(rid.intended_beneficiaries_description)),
+                    IF(rid.is_knowledge_sharing = TRUE AND rid.is_knowledge_sharing IS NOT NULL, 
+                    IF(rid.dissemination_qualification_id IS NOT NULL AND rid.dissemination_qualification_id = 2,
+                    valid_text(rid.tool_useful_context) 
+                    AND valid_text(rid.results_achieved_expected)
+                    AND rid.tool_function_id IS NOT NULL
+                    AND IF(rid.is_used_beyond_original_context = TRUE,
+                    valid_text(rid.adoption_adaptation_context),IF(rid.is_used_beyond_original_context IS NULL, FALSE, TRUE)),  IF(rid.dissemination_qualification_id IS NULL, FALSE, TRUE)) ,IF(rid.is_knowledge_sharing IS NULL, FALSE, TRUE)),
+                    cirl.level
+                    INTO
+                    commonFields,
+                    anticipatedUserId,
+                    tempSecondFields,
+                    knowledgeSharing,
+                    readinessLevel
+                FROM results r 
+                    INNER JOIN result_innovation_dev rid ON r.result_id = rid.result_id 
+                    LEFT JOIN clarisa_innovation_readiness_levels cirl ON cirl.id = rid.innovation_readiness_id
+                WHERE r.result_id = result_code
+                    AND r.is_active = TRUE
+                LIMIT 1;
+                
+                SELECT
+                    COUNT(ra.result_actors_id)
+                    INTO
+                    tempFullActors
+                FROM result_actors ra 
+                WHERE ra.result_id = result_code
+                    AND ra.is_active = TRUE;
+                
+                SELECT 
+                    IFNULL(
+                        SUM(
+                            CASE
+                                WHEN ra.actor_type_id = 5 THEN ra.actor_type_custom_name IS NOT NULL
+                                ELSE ra.actor_type_id IS NOT NULL
+                            END
+                        ), FALSE)
+                    INTO
+                    tempActors
+                FROM result_actors ra 
+                WHERE ra.result_id = result_code
+                    AND ra.is_active = TRUE;
+                
+                SELECT 
+                    IFNULL(SUM(CASE 
+                        WHEN rit.is_organization_known = TRUE THEN rit.institution_id IS NOT NULL
+                        ELSE (CASE
+                            WHEN rit.institution_type_id = 78 THEN rit.institution_type_custom_name IS NOT NULL
+                            WHEN (rit.institution_type_id != 78 AND rit.institution_type_id IS NOT NULL) THEN CASE 
+                                WHEN (SELECT COUNT(cit.code) FROM clarisa_institution_types cit WHERE cit.parent_code = rit.institution_type_id) > 0 THEN rit.sub_institution_type_id IS NOT NULL
+                                ELSE rit.institution_type_id IS NOT NULL
+                                END
+                            ELSE FALSE
+                            END)
+                        END), FALSE)
+                    INTO
+                    tempInstitutionType
+                FROM result_institution_types rit 
+                WHERE rit.result_id = result_code
+                    AND rit.is_active = TRUE;
+                    
+                SELECT 
+                    count(rit.result_institution_type_id)
+                    INTO
+                    tempFullInstitutionType
+                FROM result_institution_types rit 
+                WHERE rit.result_id = result_code
+                    AND rit.is_active = TRUE;
+                
+                RETURN IF(anticipatedUserId = 1 OR anticipatedUserId IS NULL, TRUE, (tempInstitutionType = tempFullInstitutionType) AND 
+                    (tempInstitutionType > 0) AND
+                    (tempFullActors = tempActors) AND 
+                    (tempActors > 0) AND
+                    tempSecondFields)
+                        AND commonFields  
+                        AND IF(readinessLevel >= 7, knowledgeSharing, TRUE);
+            END`);
+
+    }
+
+}

--- a/server/researchindicators/src/db/migrations/1758050480166-AddInnovationReadinessExplanationCheckValidText.ts
+++ b/server/researchindicators/src/db/migrations/1758050480166-AddInnovationReadinessExplanationCheckValidText.ts
@@ -1,0 +1,221 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddInnovationReadinessExplanationCheckValidText1758050480166 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+        DROP FUNCTION IF EXISTS \`innovation_dev_validation\`;
+        `);
+
+        await queryRunner.query(`
+        CREATE FUNCTION \`innovation_dev_validation\`(result_code BIGINT) RETURNS tinyint(1)
+        READS SQL DATA
+        BEGIN
+            DECLARE commonFields BOOLEAN DEFAULT FALSE;
+            DECLARE anticipatedUserId BIGINT DEFAULT NULL;
+            DECLARE tempSecondFields BOOLEAN DEFAULT FALSE;
+            DECLARE tempActors INT DEFAULT NULL;
+            DECLARE tempFullActors INT DEFAULT NULL;
+            DECLARE tempInstitutionType INT DEFAULT NULL;
+            DECLARE tempFullInstitutionType INT DEFAULT NULL;
+            DECLARE knowledgeSharing BOOLEAN DEFAULT FALSE;
+            DECLARE readinessLevel BIGINT DEFAULT NULL;
+
+            SELECT 
+                (valid_text(rid.short_title) AND
+                rid.innovation_nature_id IS NOT NULL AND
+                rid.innovation_type_id IS NOT NULL AND
+                rid.innovation_readiness_id IS NOT NULL AND
+                valid_text(rid.innovation_readiness_explanation) AND
+                IF(rid.is_new_or_improved_variety = TRUE, rid.new_or_improved_varieties_count > 0, TRUE) AND
+                rid.anticipated_users_id IS NOT NULL),
+                rid.anticipated_users_id,
+                (valid_text(rid.expected_outcome) AND
+                valid_text(rid.intended_beneficiaries_description)),
+                IF(rid.is_knowledge_sharing = TRUE AND rid.is_knowledge_sharing IS NOT NULL, 
+                    IF(rid.dissemination_qualification_id IS NOT NULL AND rid.dissemination_qualification_id = 2,
+                        valid_text(rid.tool_useful_context) 
+                        AND valid_text(rid.results_achieved_expected)
+                        AND rid.tool_function_id IS NOT NULL
+                        AND IF(rid.is_used_beyond_original_context = TRUE,
+                            valid_text(rid.adoption_adaptation_context),
+                            IF(rid.is_used_beyond_original_context IS NULL, FALSE, TRUE)
+                        ),  
+                        IF(rid.dissemination_qualification_id IS NULL, FALSE, TRUE)
+                    ), 
+                    IF(rid.is_knowledge_sharing IS NULL, FALSE, TRUE)
+                ),
+                cirl.level
+            INTO
+                commonFields,
+                anticipatedUserId,
+                tempSecondFields,
+                knowledgeSharing,
+                readinessLevel
+            FROM results r 
+            INNER JOIN result_innovation_dev rid ON r.result_id = rid.result_id 
+            LEFT JOIN clarisa_innovation_readiness_levels cirl ON cirl.id = rid.innovation_readiness_id
+            WHERE r.result_id = result_code
+            AND r.is_active = TRUE
+            LIMIT 1;
+            
+            SELECT COUNT(ra.result_actors_id)
+            INTO tempFullActors
+            FROM result_actors ra 
+            WHERE ra.result_id = result_code
+            AND ra.is_active = TRUE;
+            
+            SELECT IFNULL(
+                    SUM(
+                        CASE
+                            WHEN ra.actor_type_id = 5 THEN ra.actor_type_custom_name IS NOT NULL
+                            ELSE ra.actor_type_id IS NOT NULL
+                        END
+                    ), FALSE)
+            INTO tempActors
+            FROM result_actors ra 
+            WHERE ra.result_id = result_code
+            AND ra.is_active = TRUE;
+            
+            SELECT IFNULL(SUM(CASE 
+                WHEN rit.is_organization_known = TRUE THEN rit.institution_id IS NOT NULL
+                ELSE (CASE
+                    WHEN rit.institution_type_id = 78 THEN rit.institution_type_custom_name IS NOT NULL
+                    WHEN (rit.institution_type_id != 78 AND rit.institution_type_id IS NOT NULL) THEN CASE 
+                        WHEN (SELECT COUNT(cit.code) FROM clarisa_institution_types cit WHERE cit.parent_code = rit.institution_type_id) > 0 THEN rit.sub_institution_type_id IS NOT NULL
+                        ELSE rit.institution_type_id IS NOT NULL
+                        END
+                    ELSE FALSE
+                    END)
+                END), FALSE)
+            INTO tempInstitutionType
+            FROM result_institution_types rit 
+            WHERE rit.result_id = result_code
+            AND rit.is_active = TRUE;
+            
+            SELECT count(rit.result_institution_type_id)
+            INTO tempFullInstitutionType
+            FROM result_institution_types rit 
+            WHERE rit.result_id = result_code
+            AND rit.is_active = TRUE;
+            
+            RETURN IF(anticipatedUserId = 1 OR anticipatedUserId IS NULL, TRUE, (tempInstitutionType = tempFullInstitutionType) AND 
+                (tempInstitutionType > 0) AND
+                (tempFullActors = tempActors) AND 
+                (tempActors > 0) AND
+                tempSecondFields)
+                AND commonFields  
+                AND IF(readinessLevel >= 7, knowledgeSharing, TRUE);
+        END
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP FUNCTION IF EXISTS \`innovation_dev_validation\`;
+        `);
+
+        await queryRunner.query(`
+            CREATE FUNCTION \`innovation_dev_validation\`(result_code BIGINT) RETURNS tinyint(1)
+            READS SQL DATA
+            BEGIN
+                DECLARE commonFields BOOLEAN DEFAULT FALSE;
+                DECLARE anticipatedUserId BIGINT DEFAULT NULL;
+                DECLARE tempSecondFields BOOLEAN DEFAULT FALSE;
+                DECLARE tempActors INT DEFAULT NULL;
+                DECLARE tempFullActors INT DEFAULT NULL;
+                DECLARE tempInstitutionType INT DEFAULT NULL;
+                DECLARE tempFullInstitutionType INT DEFAULT NULL;
+                DECLARE knowledgeSharing BOOLEAN DEFAULT FALSE;
+                DECLARE readinessLevel BIGINT DEFAULT NULL;
+
+                SELECT 
+                    (valid_text(rid.short_title) AND
+                    rid.innovation_nature_id IS NOT NULL AND
+                    rid.innovation_type_id IS NOT NULL AND
+                    rid.innovation_readiness_id IS NOT NULL AND
+                    rid.innovation_readiness_explanation IS NOT NULL AND
+                    IF(rid.is_new_or_improved_variety = TRUE, rid.new_or_improved_varieties_count > 0, TRUE) AND
+                    rid.anticipated_users_id IS NOT NULL),
+                    rid.anticipated_users_id,
+                    (valid_text(rid.expected_outcome) AND
+                    valid_text(rid.intended_beneficiaries_description)),
+                    IF(rid.is_knowledge_sharing = TRUE AND rid.is_knowledge_sharing IS NOT NULL, 
+                        IF(rid.dissemination_qualification_id IS NOT NULL AND rid.dissemination_qualification_id = 2,
+                            valid_text(rid.tool_useful_context) 
+                            AND valid_text(rid.results_achieved_expected)
+                            AND rid.tool_function_id IS NOT NULL
+                            AND IF(rid.is_used_beyond_original_context = TRUE,
+                                valid_text(rid.adoption_adaptation_context),
+                                IF(rid.is_used_beyond_original_context IS NULL, FALSE, TRUE)
+                            ),  
+                            IF(rid.dissemination_qualification_id IS NULL, FALSE, TRUE)
+                        ), 
+                        IF(rid.is_knowledge_sharing IS NULL, FALSE, TRUE)
+                    ),
+                    cirl.level
+                INTO
+                    commonFields,
+                    anticipatedUserId,
+                    tempSecondFields,
+                    knowledgeSharing,
+                    readinessLevel
+                FROM results r 
+                INNER JOIN result_innovation_dev rid ON r.result_id = rid.result_id 
+                LEFT JOIN clarisa_innovation_readiness_levels cirl ON cirl.id = rid.innovation_readiness_id
+                WHERE r.result_id = result_code
+                AND r.is_active = TRUE
+                LIMIT 1;
+                
+                SELECT COUNT(ra.result_actors_id)
+                INTO tempFullActors
+                FROM result_actors ra 
+                WHERE ra.result_id = result_code
+                AND ra.is_active = TRUE;
+                
+                SELECT IFNULL(
+                        SUM(
+                            CASE
+                                WHEN ra.actor_type_id = 5 THEN ra.actor_type_custom_name IS NOT NULL
+                                ELSE ra.actor_type_id IS NOT NULL
+                            END
+                        ), FALSE)
+                INTO tempActors
+                FROM result_actors ra 
+                WHERE ra.result_id = result_code
+                AND ra.is_active = TRUE;
+                
+                SELECT IFNULL(SUM(CASE 
+                    WHEN rit.is_organization_known = TRUE THEN rit.institution_id IS NOT NULL
+                    ELSE (CASE
+                        WHEN rit.institution_type_id = 78 THEN rit.institution_type_custom_name IS NOT NULL
+                        WHEN (rit.institution_type_id != 78 AND rit.institution_type_id IS NOT NULL) THEN CASE 
+                            WHEN (SELECT COUNT(cit.code) FROM clarisa_institution_types cit WHERE cit.parent_code = rit.institution_type_id) > 0 THEN rit.sub_institution_type_id IS NOT NULL
+                            ELSE rit.institution_type_id IS NOT NULL
+                            END
+                        ELSE FALSE
+                        END)
+                    END), FALSE)
+                INTO tempInstitutionType
+                FROM result_institution_types rit 
+                WHERE rit.result_id = result_code
+                AND rit.is_active = TRUE;
+                
+                SELECT count(rit.result_institution_type_id)
+                INTO tempFullInstitutionType
+                FROM result_institution_types rit 
+                WHERE rit.result_id = result_code
+                AND rit.is_active = TRUE;
+                
+                RETURN IF(anticipatedUserId = 1 OR anticipatedUserId IS NULL, TRUE, (tempInstitutionType = tempFullInstitutionType) AND 
+                    (tempInstitutionType > 0) AND
+                    (tempFullActors = tempActors) AND 
+                    (tempActors > 0) AND
+                    tempSecondFields)
+                    AND commonFields  
+                    AND IF(readinessLevel >= 7, knowledgeSharing, TRUE);
+            END`);
+
+    }
+
+}

--- a/server/researchindicators/src/db/migrations/1758054920860-CorrectValidTextFunction.ts
+++ b/server/researchindicators/src/db/migrations/1758054920860-CorrectValidTextFunction.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CorrectValidTextFunction1758054920860 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+
+    await queryRunner.query(`
+      DROP FUNCTION IF EXISTS valid_text;
+    `);
+
+    await queryRunner.query(`
+      CREATE FUNCTION valid_text(text TEXT) RETURNS tinyint(1)
+      READS SQL DATA
+      DETERMINISTIC
+      BEGIN
+          RETURN IF(
+              text IS NOT NULL, 
+              LENGTH(TRIM(REGEXP_REPLACE(text, '\\\\s+', ''))) > 0, 
+              FALSE
+          );
+      END
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+
+    await queryRunner.query(`
+      DROP FUNCTION IF EXISTS valid_text;
+    `);
+
+    await queryRunner.query(`
+      CREATE FUNCTION valid_text(text TEXT) RETURNS tinyint(1)
+        READS SQL DATA
+        DETERMINISTIC
+        BEGIN
+            RETURN IF(text IS NOT NULL, LENGTH(TRIM(text)) > 0, FALSE);
+        END
+    `);
+  }
+
+}

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/dto/create-result-innovation-dev.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/dto/create-result-innovation-dev.dto.ts
@@ -92,6 +92,11 @@ export class CreateResultInnovationDevDto {
   @ApiProperty({ required: false })
   innovation_readiness_id?: number;
 
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ required: false })
+  innovation_readiness_explanation?: string;
+
   @IsBoolean()
   @IsOptional()
   @ApiProperty({ required: false })

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/entities/result-innovation-dev.entity.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/entities/result-innovation-dev.entity.ts
@@ -46,6 +46,13 @@ export class ResultInnovationDev extends AuditableEntity {
   innovation_readiness_id?: number;
 
   @Column({
+    name: 'innovation_readiness_explanation',
+    type: 'text',
+    nullable: true,
+  })
+  innovation_readiness_explanation?: string;
+
+  @Column({
     name: 'no_sex_age_disaggregation',
     type: 'boolean',
     nullable: true,

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.service.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.service.ts
@@ -208,6 +208,8 @@ export class ResultInnovationDevService {
           createResultInnovationDevDto?.innovation_nature_id,
         innovation_readiness_id:
           createResultInnovationDevDto?.innovation_readiness_id,
+        innovation_readiness_explanation:
+          createResultInnovationDevDto?.innovation_readiness_explanation,
         innovation_type_id: createResultInnovationDevDto?.innovation_type_id,
         no_sex_age_disaggregation:
           createResultInnovationDevDto?.no_sex_age_disaggregation,
@@ -420,6 +422,8 @@ export class ResultInnovationDevService {
       innovation_nature_id: resultInnovationDev.innovation_nature_id,
       innovation_type_id: resultInnovationDev.innovation_type_id,
       innovation_readiness_id: resultInnovationDev.innovation_readiness_id,
+      innovation_readiness_explanation:
+        resultInnovationDev.innovation_readiness_explanation,
       no_sex_age_disaggregation: resultInnovationDev.no_sex_age_disaggregation,
       anticipated_users_id: resultInnovationDev.anticipated_users_id,
       expected_outcome: resultInnovationDev.expected_outcome,


### PR DESCRIPTION
This pull request adds support for an `innovation_readiness_explanation` field to the innovation development result entity, including database schema changes, validation logic updates, and corresponding service and DTO modifications. It also improves the `valid_text` SQL function to better validate text fields by ignoring whitespace.

**Database schema changes:**

* Added a new nullable `innovation_readiness_explanation` column of type `text` to the `result_innovation_dev` table via a migration.
* Updated the `ResultInnovationDev` entity to include the new `innovation_readiness_explanation` property mapped to the new column.

**Validation logic updates:**

* Modified the `innovation_dev_validation` SQL function to require a valid explanation by checking `valid_text(rid.innovation_readiness_explanation)` instead of just non-null.
* Improved the `valid_text` SQL function to strip all whitespace before checking length, ensuring only meaningful text passes validation.

**DTO and service changes:**

* Added the optional `innovation_readiness_explanation` property to the `CreateResultInnovationDevDto` DTO for API input.
* Updated the `ResultInnovationDevService` to handle the new field when creating innovation development results.