### PR TITLE
✨ feat(migration): update foreign key constraints in ResultInnovationToolFunction relation

### DIFF
--- a/server/researchindicators/src/db/migrations/1758072861646-ResultInnovationToolFunctionRelationManyToMany.ts
+++ b/server/researchindicators/src/db/migrations/1758072861646-ResultInnovationToolFunctionRelationManyToMany.ts
@@ -6,7 +6,7 @@ export class ResultInnovationToolFunctionRelationManyToMany1758072861646 impleme
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` DROP FOREIGN KEY \`FK_603ec7aff1ca62ab289f8fb7c27\``);
         await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` DROP COLUMN \`tool_function_id\``);
-        await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_fb153405a8f0b1c83c04ade637d\` FOREIGN KEY (\`innovation_dev_id\`) REFERENCES \`result_innovation_dev\`(\`result_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_fb153405a8f0b1c83c04ade637d\` FOREIGN KEY (\`result_id\`) REFERENCES \`result_innovation_dev\`(\`result_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`); 
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_1a9b365c7b4bc67cacb3b0b21c2\` FOREIGN KEY (\`tool_function_id\`) REFERENCES \`tool_functions\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 


### PR DESCRIPTION
This pull request updates the migration logic for the `result_innovation_tool_function` table to correct a foreign key constraint. The change ensures that the foreign key references the correct column in the `result_innovation_dev` table.

**Database migration fix:**

* Updated the foreign key constraint in the `result_innovation_tool_function` table to reference the `result_id` column instead of the previously incorrect `innovation_dev_id`, ensuring proper relational integrity with the `result_innovation_dev` table.