### PR TITLE
✨ feat(migration): add check for existing foreign key before dropping in ResultInnovationToolFunction migration

### DIFF
--- a/server/researchindicators/src/db/migrations/1758072861646-ResultInnovationToolFunctionRelationManyToMany.ts
+++ b/server/researchindicators/src/db/migrations/1758072861646-ResultInnovationToolFunctionRelationManyToMany.ts
@@ -4,7 +4,20 @@ export class ResultInnovationToolFunctionRelationManyToMany1758072861646 impleme
     name = 'ResultInnovationToolFunctionRelationManyToMany1758072861646'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` DROP FOREIGN KEY \`FK_603ec7aff1ca62ab289f8fb7c27\``);
+        const fk = await queryRunner.query(`
+            SELECT CONSTRAINT_NAME
+            FROM information_schema.KEY_COLUMN_USAGE
+            WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'result_innovation_dev'
+                AND CONSTRAINT_NAME = 'FK_603ec7aff1ca62ab289f8fb7c27'
+        `);
+
+        if (fk.length > 0) {
+        await queryRunner.query(`
+            ALTER TABLE \`result_innovation_dev\`
+            DROP FOREIGN KEY \`FK_603ec7aff1ca62ab289f8fb7c27\`
+        `);
+        }
         await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` DROP COLUMN \`tool_function_id\``);
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_fb153405a8f0b1c83c04ade637d\` FOREIGN KEY (\`result_id\`) REFERENCES \`result_innovation_dev\`(\`result_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`); 
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_1a9b365c7b4bc67cacb3b0b21c2\` FOREIGN KEY (\`tool_function_id\`) REFERENCES \`tool_functions\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);


### PR DESCRIPTION
This pull request improves the migration script for the `result_innovation_dev` table to make it more robust. The main change is adding a check to ensure that the foreign key exists before attempting to drop it, which prevents errors if the foreign key is missing.

**Migration robustness improvement:**

* Updated the `up` method in `ResultInnovationToolFunctionRelationManyToMany1758072861646` to check for the existence of the foreign key `FK_603ec7aff1ca62ab289f8fb7c27` before attempting to drop it, preventing potential runtime errors during migration.