### PR TITLE
♻️ refactor(migration): add checks for column existence before dropping

### DIFF
--- a/server/researchindicators/src/db/migrations/1758072861646-ResultInnovationToolFunctionRelationManyToMany.ts
+++ b/server/researchindicators/src/db/migrations/1758072861646-ResultInnovationToolFunctionRelationManyToMany.ts
@@ -18,7 +18,15 @@ export class ResultInnovationToolFunctionRelationManyToMany1758072861646 impleme
             DROP FOREIGN KEY \`FK_603ec7aff1ca62ab289f8fb7c27\`
         `);
         }
-        await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` DROP COLUMN \`tool_function_id\``);
+
+        const table = await queryRunner.getTable("result_innovation_dev");
+
+        if (table && table.findColumnByName("tool_function_id")) {
+        await queryRunner.query(
+            "ALTER TABLE `result_innovation_dev` DROP COLUMN `tool_function_id`"
+        );
+        }
+
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_fb153405a8f0b1c83c04ade637d\` FOREIGN KEY (\`result_id\`) REFERENCES \`result_innovation_dev\`(\`result_id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`); 
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` ADD CONSTRAINT \`FK_1a9b365c7b4bc67cacb3b0b21c2\` FOREIGN KEY (\`tool_function_id\`) REFERENCES \`tool_functions\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
@@ -26,7 +34,13 @@ export class ResultInnovationToolFunctionRelationManyToMany1758072861646 impleme
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` DROP FOREIGN KEY \`FK_1a9b365c7b4bc67cacb3b0b21c2\``);
         await queryRunner.query(`ALTER TABLE \`result_innovation_tool_function\` DROP FOREIGN KEY \`FK_fb153405a8f0b1c83c04ade637d\``);
-        await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` ADD \`tool_function_id\` bigint NULL`);
+        
+        const table = await queryRunner.getTable("result_innovation_dev");
+        if (table && !table.findColumnByName("tool_function_id")) {
+        await queryRunner.query(
+            "ALTER TABLE `result_innovation_dev` ADD `tool_function_id` int NULL"
+        );
+        }
         await queryRunner.query(`ALTER TABLE \`result_innovation_dev\` ADD CONSTRAINT \`FK_603ec7aff1ca62ab289f8fb7c27\` FOREIGN KEY (\`tool_function_id\`) REFERENCES \`tool_functions\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 


### PR DESCRIPTION
This pull request improves the safety and reliability of the database migration for the `result_innovation_dev` table by adding checks before altering the `tool_function_id` column. This helps prevent errors during migration if the column's existence does not match expectations.

Database migration improvements:

* Added a check before dropping the `tool_function_id` column from the `result_innovation_dev` table to ensure the column exists, preventing errors if the column is already missing.
* Added a check before adding the `tool_function_id` column back in the `down` migration to ensure the column does not already exist, and changed its type from `bigint` to `int` for consistency.…ng and adding tool_function_id in ResultInnovationToolFunction migration