### PR TITLE
Ac 1069 us4 download oicr template with pre filled information back

### DIFF
--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -41,4 +41,5 @@ export class ResultMappedDto {
   regions: RegionDto[];
   countries: CountryDto[];
   geographic_scope_comments: string;
+  handle_link: string;
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/response-oicr-word-template.dto.ts
@@ -34,12 +34,12 @@ export class ResultMappedDto {
   other_projects: ProjectDto[];
   tag_id: number | null;
   tag_name: string | null;
-  outcome_impact_statement: string;
+  outcome_impact_statement: string | null;
   main_levers: MainLeverDto[];
   other_levers: LeverDto[];
-  geographic_scope: string;
+  geographic_scope: string | null;
   regions: RegionDto[];
   countries: CountryDto[];
-  geographic_scope_comments: string;
-  handle_link: string;
+  geographic_scope_comments: string | null;
+  handle_link: string | null;
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -111,7 +111,7 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
       LEFT JOIN TEMP_result_external_oicrs treo on treo.result_id = r.result_id
         AND treo.is_active = TRUE
       LEFT JOIN TEMP_external_oicrs teo on teo.id = treo.external_oicr_id
-      WHERE r.result_id = 3311
+      WHERE r.result_id = ?
         AND r.is_active = TRUE;
     `;
     return await this.query(query, [resultId]);

--- a/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/repositories/result-oicr.repository.ts
@@ -49,7 +49,7 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
 
   async getResultOicrDetailsByOfficialCode(resultId: number) {
     const query = `
-      SELECT
+    SELECT
         r.result_id,
         r.result_official_code as result_code,
         r.title,
@@ -71,7 +71,8 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
         cr.name as region_name,
         cc.isoAlpha2 as country_code,
         cc.name as country_name,
-        r.comment_geo_scope
+        r.comment_geo_scope,
+        teo.handle_link
       FROM results r
       INNER JOIN result_oicrs ro ON ro.result_id = r.result_id
       INNER JOIN result_contracts rc_main 
@@ -107,7 +108,10 @@ export class ResultOicrRepository extends Repository<ResultOicr> {
       LEFT JOIN result_countries rco on rco.result_id = r.result_id
         AND rco.is_active = TRUE
       LEFT JOIN clarisa_countries cc on cc.isoAlpha2 = rco.isoAlpha2
-      WHERE r.result_id = ?
+      LEFT JOIN TEMP_result_external_oicrs treo on treo.result_id = r.result_id
+        AND treo.is_active = TRUE
+      LEFT JOIN TEMP_external_oicrs teo on teo.id = treo.external_oicr_id
+      WHERE r.result_id = 3311
         AND r.is_active = TRUE;
     `;
     return await this.query(query, [resultId]);

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -506,16 +506,16 @@ export class ResultOicrService {
       main_project_id: firstRow.main_project_id,
       main_project: firstRow.main_project_title,
       other_projects: Array.from(projectsMap.values()),
-      tag_id: firstRow.tag_id,
-      tag_name: firstRow.tag_name,
-      outcome_impact_statement: firstRow.outcome_impact_statement,
+      tag_id: firstRow.tag_id ?? '',
+      tag_name: firstRow.tag_name ?? '',
+      outcome_impact_statement: firstRow.outcome_impact_statement ?? '',
       main_levers: Array.from(mainLeversMap.values()),
       other_levers: Array.from(leversMap.values()),
-      geographic_scope: firstRow.geographic_scope,
+      geographic_scope: firstRow.geographic_scope ?? '',
       regions: Array.from(regionsMap.values()),
       countries: Array.from(countriesMap.values()),
-      geographic_scope_comments: firstRow.comment_geo_scope,
-      handle_link: firstRow.handle_link,
+      geographic_scope_comments: firstRow.comment_geo_scope ?? '',
+      handle_link: firstRow.handle_link ?? '',
     };
   }
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -515,6 +515,7 @@ export class ResultOicrService {
       regions: Array.from(regionsMap.values()),
       countries: Array.from(countriesMap.values()),
       geographic_scope_comments: firstRow.comment_geo_scope,
+      handle_link: firstRow.handle_link,
     };
   }
 }


### PR DESCRIPTION
This pull request updates the OICR result data model and related repository/service logic to improve handling of optional fields and to include a new external link reference. The main changes ensure that several fields can be nullable, add support for an external handle link, and update query logic to retrieve this new data.

**Data model improvements:**

* Updated the `ResultMappedDto` class to allow `outcome_impact_statement`, `geographic_scope`, and `geographic_scope_comments` to be nullable, and added a new nullable `handle_link` field to support external references.

**Repository/query enhancements:**

* Modified the SQL query in `ResultOicrRepository` to join with new temporary tables and select the `handle_link` field, enabling retrieval of external OICR links. [[1]](diffhunk://#diff-5a4e324cf9caf7a36fdadeaba8aebd082fb1b001fc9fc6fe79ca13c2866ded82L74-R75) [[2]](diffhunk://#diff-5a4e324cf9caf7a36fdadeaba8aebd082fb1b001fc9fc6fe79ca13c2866ded82R111-R113)

**Service logic updates:**

* Updated the mapping logic in `ResultOicrService` to handle potentially missing values for several fields, using default empty strings, and to include the new `handle_link` field in the result object.