### PR TITLE
✨ feat(api): add isEmpty check to handle empty search results in getBulkElasticOperation method

### DIFF
--- a/server/researchindicators/src/domain/entities/agresso-contract/agresso-contract.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/agresso-contract.controller.spec.ts
@@ -256,10 +256,10 @@ describe('AgressoContractController', () => {
         '2023-01-01',
         '2023-12-31',
         OrderFieldsEnum.START_DATE,
-        'DESC',
         '1',
         '10',
         'test query',
+        'DESC',
       );
 
       expect(service.findAgressoContracts).toHaveBeenCalledWith(
@@ -305,9 +305,9 @@ describe('AgressoContractController', () => {
         undefined,
         undefined,
         undefined,
-        undefined,
         '1',
         '10',
+        undefined,
         undefined,
       );
 
@@ -351,10 +351,10 @@ describe('AgressoContractController', () => {
         undefined,
         undefined,
         undefined,
-        'ASC',
         '1',
         '10',
         undefined,
+        'ASC',
       );
 
       expect(service.findAgressoContracts).toHaveBeenCalledWith(

--- a/server/researchindicators/src/domain/tools/open-search/core/base-open-search-api.ts
+++ b/server/researchindicators/src/domain/tools/open-search/core/base-open-search-api.ts
@@ -26,6 +26,7 @@ import {
   PropertyDescriptor,
   SearchFields,
 } from './types/base-open-search.types';
+import { isEmpty } from '../../../shared/utils/object.utils';
 
 export abstract class BaseOpenSearchApi<
   Entity,
@@ -390,7 +391,8 @@ export abstract class BaseOpenSearchApi<
       >(`${this._index}/_search`, elasticQuery, this._config),
     )
       .then((response) => {
-        return response.data?.hits?.hits?.map((hit) => ({
+        if (isEmpty(response?.data?.hits?.hits)) return [];
+        return response.data.hits.hits.map((hit) => ({
           ...hit._source,
           score: hit._score,
         }));


### PR DESCRIPTION
This pull request introduces a small fix to the order of parameters in test cases for the `AgressoContractController` and improves the robustness of the `BaseOpenSearchApi` by handling empty search results. The most significant changes are grouped below:

**Testing improvements:**

* Fixed the order of parameters in multiple test cases for `AgressoContractController` to ensure the correct placement of the sort order argument (`'DESC'` or `'ASC'`). [[1]](diffhunk://#diff-248d9476c6e12647569ad9ed8200cb65b7db67db9e94075905a58dc8b31242f7L259-R262) [[2]](diffhunk://#diff-248d9476c6e12647569ad9ed8200cb65b7db67db9e94075905a58dc8b31242f7L308-R311) [[3]](diffhunk://#diff-248d9476c6e12647569ad9ed8200cb65b7db67db9e94075905a58dc8b31242f7L354-R357)

**OpenSearch API robustness:**

* Added an import for `isEmpty` from `object.utils` to support empty result checks.
* Updated the `BaseOpenSearchApi` to return an empty array when no search results are found, preventing potential errors from undefined mappings.