### PR TITLE
Refactor AI organization mapping for innovation development results

### DIFF
--- a/server/researchindicators/src/domain/entities/result-capacity-sharing/result-capacity-sharing.module.ts
+++ b/server/researchindicators/src/domain/entities/result-capacity-sharing/result-capacity-sharing.module.ts
@@ -33,9 +33,9 @@ import { ClarisaLanguagesModule } from '../../tools/clarisa/entities/clarisa-lan
     ClarisaCountriesModule,
     GendersModule,
     AllianceUserStaffModule,
-    ClarisaLanguagesModule
+    ClarisaLanguagesModule,
   ],
   providers: [ResultCapacitySharingService, AiRoarMiningApp],
   exports: [ResultCapacitySharingService],
 })
-export class ResultCapacitySharingModule { }
+export class ResultCapacitySharingModule {}

--- a/server/researchindicators/src/domain/entities/result-capacity-sharing/result-capacity-sharing.service.ts
+++ b/server/researchindicators/src/domain/entities/result-capacity-sharing/result-capacity-sharing.service.ts
@@ -166,8 +166,8 @@ export class ResultCapacitySharingService {
 
     tempCapSharing.nationality = clean_nationality
       ? ({
-        isoAlpha2: clean_nationality.isoAlpha2,
-      } as ResultCountry)
+          isoAlpha2: clean_nationality.isoAlpha2,
+        } as ResultCountry)
       : null;
 
     const clean_gender = await nextToProcessAiRaw(

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.service.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.service.ts
@@ -69,6 +69,7 @@ export class ResultInnovationDevService {
   async processedCenters(
     centers: OrganizationDetailed[],
   ): Promise<CreateResultInstitutionTypeDto[]> {
+    if (isEmpty(centers)) return [];
     const newInstitutionTypes: CreateResultInstitutionTypeDto[] = [];
     for (const center of centers) {
       const isInstitutionValid = validObject(center, [
@@ -265,14 +266,14 @@ export class ResultInnovationDevService {
           createResultInnovationDevDto?.anticipated_users_id,
         ...(adddExtraData
           ? {
-              expected_outcome: createResultInnovationDevDto?.expected_outcome,
-              intended_beneficiaries_description:
-                createResultInnovationDevDto?.intended_beneficiaries_description,
-            }
+            expected_outcome: createResultInnovationDevDto?.expected_outcome,
+            intended_beneficiaries_description:
+              createResultInnovationDevDto?.intended_beneficiaries_description,
+          }
           : {
-              expected_outcome: null,
-              intended_beneficiaries_description: null,
-            }),
+            expected_outcome: null,
+            intended_beneficiaries_description: null,
+          }),
         ...this._currentUser.audit(SetAuditEnum.UPDATE),
       });
 
@@ -296,8 +297,8 @@ export class ResultInnovationDevService {
         resultId,
         adddExtraData
           ? createResultInnovationDevDto?.institution_types?.filter((el) =>
-              Boolean(el?.institution_type_id || el?.institution_id),
-            )
+            Boolean(el?.institution_type_id || el?.institution_id),
+          )
           : [],
         manager,
       );

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.service.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.service.ts
@@ -18,13 +18,18 @@ import { ClarisaActorTypesService } from '../../tools/clarisa/entities/clarisa-a
 import {
   isEmpty,
   setDefaultValueInObject,
+  validObject,
+  validObjectAnyOf,
 } from '../../shared/utils/object.utils';
 import { LinkResultsService } from '../link-results/link-results.service';
 import { LinkResult } from '../link-results/entities/link-result.entity';
 import { LinkResultRolesEnum } from '../link-result-roles/enum/link-result-roles.enum';
 import { UpdateDataUtil } from '../../shared/utils/update-data.util';
 import { ClarisaInnovationReadinessLevel } from '../../tools/clarisa/entities/clarisa-innovation-readiness-levels/entities/clarisa-innovation-readiness-level.entity';
-import { ResultRawAi } from '../results/dto/result-ai.dto';
+import {
+  OrganizationDetailed,
+  ResultRawAi,
+} from '../results/dto/result-ai.dto';
 import { ClarisaInnovationCharacteristicsService } from '../../tools/clarisa/entities/clarisa-innovation-characteristics/clarisa-innovation-characteristics.service';
 import { ClarisaInnovationTypesService } from '../../tools/clarisa/entities/clarisa-innovation-types/clarisa-innovation-types.service';
 import { ClarisaInnovationReadinessLevelsService } from '../../tools/clarisa/entities/clarisa-innovation-readiness-levels/clarisa-innovation-readiness-levels.service';
@@ -32,14 +37,16 @@ import { InnovationDevAnticipatedUsersService } from '../innovation-dev-anticipa
 import { ClarisaActorTypesEnum } from '../../tools/clarisa/entities/clarisa-actor-types/enum/clarisa-actor-types.enum';
 import { CreateResultActorDto } from '../result-actors/dto/create-result-actor.dto';
 import { ClarisaInstitutionsService } from '../../tools/clarisa/entities/clarisa-institutions/clarisa-institutions.service';
-import { ClarisaInstitution } from '../../tools/clarisa/entities/clarisa-institutions/entities/clarisa-institution.entity';
 import { CreateResultInstitutionTypeDto } from '../result-institution-types/dto/create-result-institution-type.dto';
 import { ClarisaInstitutionTypesService } from '../../tools/clarisa/entities/clarisa-institution-types/clarisa-institution-types.service';
 import { ResultInnovationToolFunction } from '../result-innovation-tool-function/entities/result-innovation-tool-function.entity';
 import { ResultInnovationToolFunctionService } from '../result-innovation-tool-function/result-innovation-tool-function.service';
+import { CgiarLogger } from '../../shared/utils/cgiar-logs/logs.util';
+import { ClarisaInstitutionTypeEnum } from '../../tools/clarisa/entities/clarisa-institution-types/enum/clarisa-institution-type.enum';
 @Injectable()
 export class ResultInnovationDevService {
   private readonly mainRepo: Repository<ResultInnovationDev>;
+  private readonly logger = new CgiarLogger(ResultInnovationDevService.name);
   constructor(
     private readonly dataSource: DataSource,
     private readonly _currentUser: CurrentUserUtil,
@@ -57,6 +64,88 @@ export class ResultInnovationDevService {
     private readonly _resultInnovationToolFunctionService: ResultInnovationToolFunctionService,
   ) {
     this.mainRepo = this.dataSource.getRepository(ResultInnovationDev);
+  }
+
+  async processedCenters(
+    centers: OrganizationDetailed[],
+  ): Promise<CreateResultInstitutionTypeDto[]> {
+    const newInstitutionTypes: CreateResultInstitutionTypeDto[] = [];
+    for (const center of centers) {
+      const isInstitutionValid = validObject(center, [
+        'institution_id',
+        'similarity_score',
+      ]).isValid;
+      const isCenterValid = validObjectAnyOf(center, [
+        'type',
+        'sub_type',
+        'other_type',
+      ]).isValid;
+      const anyValid = isInstitutionValid || isCenterValid;
+      if (anyValid) {
+        const newInstitutionType = new CreateResultInstitutionTypeDto();
+        if (isInstitutionValid) {
+          const institution = await this._clarisaInstitutionsService.findOne(
+            center.institution_id,
+          );
+          if (isEmpty(institution)) {
+            this.logger.warn(
+              `Institution with ID ${center.institution_id}: ${center?.institution_name} not found`,
+            );
+            continue;
+          }
+          newInstitutionType.institution_id = institution.code;
+          newInstitutionType.is_organization_known = true;
+          newInstitutionTypes.push(newInstitutionType);
+        } else if (isCenterValid) {
+          const institutionType = await this.processedInstitutionTypes(center);
+          if (isEmpty(institutionType)) {
+            this.logger.warn(
+              `Institution type with name ${center.type} not found`,
+            );
+            continue;
+          }
+          newInstitutionTypes.push(institutionType);
+        }
+      }
+    }
+    return newInstitutionTypes;
+  }
+
+  async processedInstitutionTypes(
+    institutionTypes: OrganizationDetailed,
+  ): Promise<CreateResultInstitutionTypeDto> {
+    let newInstitutionTypes = new CreateResultInstitutionTypeDto();
+    newInstitutionTypes.is_organization_known = false;
+    if (!isEmpty(institutionTypes?.other_type)) {
+      newInstitutionTypes.institution_type_id =
+        ClarisaInstitutionTypeEnum.OTHER;
+      newInstitutionTypes.institution_type_custom_name =
+        institutionTypes.other_type;
+    } else if (!isEmpty(institutionTypes?.sub_type)) {
+      const subType = await this._clarisaInstitutionTypesService.findByName(
+        institutionTypes.sub_type,
+      );
+      if (subType) {
+        newInstitutionTypes.institution_type_id = subType.parent?.code;
+        newInstitutionTypes.sub_institution_type_id = subType.code;
+      } else {
+        this.logger.warn(
+          `Sub type with name ${institutionTypes.sub_type} not found`,
+        );
+        newInstitutionTypes = null;
+      }
+    } else {
+      const type = await this._clarisaInstitutionTypesService.findByName(
+        institutionTypes.type,
+      );
+      if (type) {
+        newInstitutionTypes.institution_type_id = type.code;
+      } else {
+        this.logger.warn(`Type with name ${institutionTypes.type} not found`);
+        newInstitutionTypes = null;
+      }
+    }
+    return newInstitutionTypes;
   }
 
   async processedAiInfo(
@@ -103,69 +192,10 @@ export class ResultInnovationDevService {
     }
     innovationDev.actors = newActors as CreateResultActorDto[];
 
-    const organizationsNames = result.organizations;
-    let clarisaInstitutions: ClarisaInstitution[] = [];
-    if (Array.isArray(organizationsNames) && organizationsNames.length > 0) {
-      clarisaInstitutions =
-        await this._clarisaInstitutionsService.findByLikeNames(
-          organizationsNames,
-        );
-    }
+    const organizationsDetailed = result.organizations_detailed;
     const newInstitutionTypes: Partial<CreateResultInstitutionTypeDto>[] = [];
-
-    for (const institution of clarisaInstitutions) {
-      newInstitutionTypes.push({
-        institution_type_id: null,
-        sub_institution_type_id: null,
-        institution_type_custom_name: null,
-        is_organization_known: true,
-        institution_id: institution.code,
-      });
-    }
-
-    const preProcessedTypes = this.processDataArrayString(
-      result?.organization_type,
-    );
-    const clarisaInstitutionsType = preProcessedTypes.length
-      ? await this._clarisaInstitutionTypesService.findByLikeNames(
-          preProcessedTypes,
-        )
-      : [];
-    const newArray: string[] = Array.isArray(result?.organization_sub_type)
-      ? result?.organization_sub_type
-      : result?.organization_sub_type !== 'Not collected'
-        ? [result?.organization_sub_type]
-        : [];
-
-    const preProcessedSubTypes = this.processDataArrayString(
-      newArray?.filter(Boolean),
-    );
-
-    const clarisaInstitutionsSubType = preProcessedSubTypes.length
-      ? await this._clarisaInstitutionTypesService.findByLikeNames(
-          preProcessedSubTypes,
-        )
-      : [];
-
-    for (const institutionsType of clarisaInstitutionsType) {
-      newInstitutionTypes.push({
-        institution_type_id: institutionsType.code,
-        sub_institution_type_id: null,
-        institution_type_custom_name: null,
-        is_organization_known: false,
-        institution_id: null,
-      });
-    }
-
-    for (const institutionsSubType of clarisaInstitutionsSubType) {
-      newInstitutionTypes.push({
-        institution_type_id: institutionsSubType?.parent?.code,
-        sub_institution_type_id: institutionsSubType.code,
-        institution_type_custom_name: null,
-        is_organization_known: false,
-        institution_id: null,
-      });
-    }
+    const centers = await this.processedCenters(organizationsDetailed);
+    newInstitutionTypes.push(...centers);
 
     innovationDev.institution_types =
       newInstitutionTypes as CreateResultInstitutionTypeDto[];

--- a/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.ts
+++ b/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.ts
@@ -278,7 +278,6 @@ export class ResultStatusWorkflowService {
         result_status_id: toStatusId,
         ...this.currentUserUtil.audit(SetAuditEnum.UPDATE),
       });
-      console.log(JSON.stringify(transitionStatus, null, 2));
       await this._executeConfigWorkflow(
         transitionStatus.config,
         manager,

--- a/server/researchindicators/src/domain/entities/results/dto/result-ai.dto.ts
+++ b/server/researchindicators/src/domain/entities/results/dto/result-ai.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { UpdateResultCapacitySharingDto } from '../../result-capacity-sharing/dto/update-result-capacity-sharing.dto';
 import { CreateResultPolicyChangeDto } from '../../result-policy-change/dto/create-result-policy-change.dto';
 import { CreateResultDto } from './create-result.dto';
@@ -218,6 +218,32 @@ export class AiRawLanguage {
   @IsString()
   @IsNotEmpty()
   code: string;
+}
+
+export class OrganizationDetailed extends PartialType(AiRawInstitution) {
+  @ApiProperty({
+    type: String,
+    description: 'Type of the organization',
+  })
+  @IsString()
+  @IsOptional()
+  type?: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Sub type of the organization',
+  })
+  @IsString()
+  @IsOptional()
+  sub_type?: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Other type of the organization',
+  })
+  @IsString()
+  @IsOptional()
+  other_type?: string;
 }
 
 export class ResultRawAi {
@@ -613,43 +639,16 @@ export class ResultRawAi {
   innovation_actors_detailed: ResultInnovationActorDetailedDto[];
 
   @ApiProperty({
-    type: String,
+    type: OrganizationDetailed,
     isArray: true,
-    description: 'Organizations involved in the result',
+    description: 'Detailed information about the organizations',
     required: false,
   })
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
-  organizations: string[];
-
-  @ApiProperty({
-    type: [String],
-    description: 'Organization type of the result',
-    required: false,
-  })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  organization_type: string[];
-
-  @ApiProperty({
-    type: [String],
-    description: 'Sub-type of the organization if applicable',
-    required: false,
-  })
-  @IsOptional()
-  organization_sub_type: string | string[];
-
-  @ApiProperty({
-    type: [String],
-    description: 'Other organization type if applicable',
-    required: false,
-  })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  other_organization_type: string[];
+  @ValidateNested({ each: true })
+  @Type(() => OrganizationDetailed)
+  organizations_detailed: OrganizationDetailed[];
 
   @ApiProperty({
     type: Number,

--- a/server/researchindicators/src/domain/entities/results/results.service.ts
+++ b/server/researchindicators/src/domain/entities/results/results.service.ts
@@ -131,7 +131,7 @@ export class ResultsService {
     private readonly _resultLeverStrategicOutcomeService: ResultLeverStrategicOutcomeService,
     private readonly _resultKnowledgeProductService: ResultKnowledgeProductService,
     private readonly _resultsUtil: ResultsUtil,
-  ) { }
+  ) {}
 
   async findResults(filters: Partial<ResultFiltersInterface>) {
     return this.mainRepo.findResultsFilters({
@@ -641,19 +641,19 @@ export class ResultsService {
       const primaryLevers: Partial<ResultLever>[] =
         primary_levers?.length > 0
           ? primary_levers.map((el) => ({
-            lever_id: el.lever_id,
-            is_primary: true,
-            result_lever_strategic_outcomes:
-              el?.result_lever_strategic_outcomes,
-          }))
+              lever_id: el.lever_id,
+              is_primary: true,
+              result_lever_strategic_outcomes:
+                el?.result_lever_strategic_outcomes,
+            }))
           : [];
 
       const contributorLevers: Partial<ResultLever>[] =
         contributor_levers?.length > 0
           ? contributor_levers.map((el) => ({
-            lever_id: el.lever_id,
-            is_primary: false,
-          }))
+              lever_id: el.lever_id,
+              is_primary: false,
+            }))
           : [];
 
       const fullLevers = filterByUniqueKeyWithPriority<Partial<ResultLever>>(
@@ -1001,9 +1001,10 @@ export class ResultsService {
       : null;
     tempIpRights.potential_asset_description =
       result?.potential_asset_description;
-    tempIpRights.requires_futher_development = result?.requires_further_development
-      ? result?.requires_further_development === 'Yes'
-      : null;
+    tempIpRights.requires_futher_development =
+      result?.requires_further_development
+        ? result?.requires_further_development === 'Yes'
+        : null;
     tempIpRights.requires_futher_development_description =
       result?.requires_further_development_description;
     return tempIpRights;
@@ -1194,8 +1195,8 @@ export class ResultsService {
         (country) => {
           country.result_countries_sub_nationals = country?.is_active
             ? saveGeoLocationDto.countries.find(
-              (el) => el.isoAlpha2 === country.isoAlpha2,
-            )?.result_countries_sub_nationals
+                (el) => el.isoAlpha2 === country.isoAlpha2,
+              )?.result_countries_sub_nationals
             : [];
           return country;
         },

--- a/server/researchindicators/src/domain/shared/utils/object.utils.ts
+++ b/server/researchindicators/src/domain/shared/utils/object.utils.ts
@@ -39,6 +39,35 @@ export const validObject = <T>(
   };
 };
 
+export const validObjectAnyOf = <T>(
+  obj: Partial<T>,
+  valid: (keyof T)[],
+): ValidationResult => {
+  const invalidFields: string[] = [];
+
+  if (!valid?.length) {
+    return {
+      isValid: false,
+      invalidFields,
+    };
+  }
+
+  for (const key of valid) {
+    if (!isEmpty(obj[key])) {
+      return {
+        isValid: true,
+        invalidFields: [],
+      };
+    }
+    invalidFields.push(key as string);
+  }
+
+  return {
+    isValid: false,
+    invalidFields,
+  };
+};
+
 export const isEmpty = <T>(attr: T) => {
   return (
     attr === null ||

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-institution-types/clarisa-institution-types.service.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-institution-types/clarisa-institution-types.service.ts
@@ -25,6 +25,19 @@ export class ClarisaInstitutionTypesService extends ControlListBaseService<
     return this.mainRepo.findActiveWithNoChildren();
   }
 
+  async findByName(name: string): Promise<ClarisaInstitutionType> {
+    const where: FindOptionsWhere<ClarisaInstitutionType> = {
+      is_active: true,
+      name: Like(`%${name}%`),
+    } as FindOptionsWhere<ClarisaInstitutionType>;
+    return this.mainRepo.findOne({
+      where: where,
+      relations: {
+        parent: true,
+      },
+    });
+  }
+
   async getChildlessInstitutionTypes() {
     const institutionsType = await this.mainRepo.find({
       where: { is_active: true },


### PR DESCRIPTION
## Summary

Refactors how organization data from AI is mapped for **result innovation development**. Flat string/array fields are replaced by a structured `organizations_detailed` list, with explicit validation, CLARISA lookups, logging when lookups fail, and an early return when there are no centers.

## Changes

### AI DTO (`ResultRawAi`)

| Before | After |
|--------|--------|
| `organizations`, `organization_type`, `organization_sub_type`, `other_organization_type` | Single field: `organizations_detailed: OrganizationDetailed[]` |

- New **`OrganizationDetailed`**: extends institution-related fields with optional `type`, `sub_type`, and `other_type`, with nested validation.

### `ResultInnovationDevService`

- **`processedCenters`**: walks `organizations_detailed`, validates with `validObject` / `validObjectAnyOf`, resolves known institutions by ID or builds rows via **`processedInstitutionTypes`**.
- **`processedInstitutionTypes`**: handles `other_type` (OTHER + custom name), `sub_type` and `type` via **`ClarisaInstitutionTypesService.findByName`** (including parent for sub-types).
- **`CgiarLogger`**: warns when institution or type cannot be resolved.
- **Follow-up**: `processedCenters` returns `[]` immediately when `centers` is empty; minor formatting in related branches.

### Shared utilities

- **`validObjectAnyOf`** in `object.utils.ts`: at least one of the given keys must be non-empty for the object to be considered valid.

### CLARISA

- **`ClarisaInstitutionTypesService.findByName`**: fuzzy lookup on active types, with `parent` relation loaded.

### Other

- Removed debug **`console.log`** in `ResultStatusWorkflowService` on status transition.
- Minor formatting-only edits in `result-capacity-sharing` and `results.service`.

## Breaking change / integration

Callers must send **`organizations_detailed`** instead of the removed organization fields. Update any producer of `ResultRawAi` accordingly.

## Commits

- `d6a3392223abb13c2c201cf1922156468c9ea9cc` — Structured organizations, validation, `findByName`, logger, DTO update.
- `5e991d5b660c1302d642323b587fa52c57c0004a` — Early return for empty centers + formatting.