### PR TITLE
feat: SDG targets API, lever ordering, AI bulk results roles, and test/coverage updates

### DIFF
--- a/server/researchindicators/package.json
+++ b/server/researchindicators/package.json
@@ -126,7 +126,9 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s",
       "!**/*.spec.ts",
-      "!**/*.entity.ts"
+      "!**/*.entity.ts",
+      "!**/db/migrations/**",
+      "!**/*.enum.ts"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"

--- a/server/researchindicators/src/db/migrations/1776433682077-InsertNewRoles.ts
+++ b/server/researchindicators/src/db/migrations/1776433682077-InsertNewRoles.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { SecRolesEnum } from '../../domain/shared/enum/sec_role.enum';
+
+export class InsertNewRoles1776433682077 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`INSERT INTO app_config 
+                                 (created_at,created_by,updated_at,updated_by,is_active,deleted_at,\`key\`,description,simple_value,json_value,category,subcategory,field) VALUES
+                                 ('2026-04-15 15:38:10.437267',NULL,'2026-04-15 15:38:10.437267',NULL,1,NULL,'BULK_UPLOAD.EMBED_INFO.URL','External URL to load the bulk upload appliation','https://datb5ly7vwnl2.cloudfront.net/',NULL,'BULK_UPLOAD','EMBED_INFO','URL')
+                                 ;`);
+
+    await queryRunner.query(`INSERT INTO sec_roles 
+                                 (created_at,created_by,updated_at,updated_by,is_active,justification_update,sec_role_id,name,focus_id,deleted_at) VALUES
+                                 ('2026-04-15 15:40:46.297915',NULL,'2026-04-15 15:40:46.297915',NULL,1,NULL,${SecRolesEnum.CENTER_ADMIN},'Center Admin',1,NULL)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM app_config WHERE \`key\` = 'BULK_UPLOAD.EMBED_INFO.URL'`,
+    );
+    await queryRunner.query(
+      `DELETE FROM sec_roles WHERE sec_role_id = ${SecRolesEnum.CENTER_ADMIN}`,
+    );
+  }
+}

--- a/server/researchindicators/src/domain/entities/green-checks/green-checks.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/green-checks/green-checks.service.spec.ts
@@ -91,7 +91,6 @@ describe('GreenChecksService', () => {
     INTERNAL_EMAIL_LIST: 'internal@test.com',
   };
 
-  /** Misma referencia en todo el ciclo de vida del módulo Nest (mutar por test). */
   const resultsUtilStub = {
     statusId: ResultStatusEnum.SUBMITTED,
     indicatorId: IndicatorsEnum.KNOWLEDGE_PRODUCT,
@@ -100,7 +99,6 @@ describe('GreenChecksService', () => {
     resultId: 50,
   };
 
-  /** prepareEmail → prepareDataToEmail exige promesas en repositorio / plantilla. */
   const stubNonOicrEmailData = () => {
     getDataForReviseResult.mockResolvedValue({
       sub_email: 'sub@test.com',

--- a/server/researchindicators/src/domain/entities/green-checks/green-checks.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/green-checks/green-checks.service.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { GreenChecksService } from './green-checks.service';
 import { GreenCheckRepository } from './repository/green-checks.repository';
@@ -19,6 +23,8 @@ import { ResultsUtil } from '../../shared/utils/results.util';
 import { ResultOicrService } from '../result-oicr/result-oicr.service';
 import { IndicatorsEnum } from '../indicators/enum/indicators.enum';
 import { TemplateEnum } from '../../shared/auxiliar/template/enum/template.enum';
+import { SecRolesEnum } from '../../shared/enum/sec_role.enum';
+import { OptionalBody } from './dto/optional-body.dto';
 
 describe('GreenChecksService', () => {
   let service: GreenChecksService;
@@ -65,6 +71,7 @@ describe('GreenChecksService', () => {
 
   const mockCurrentUser = {
     user_id: 1,
+    roles: [SecRolesEnum.SUP_ADMIN],
     user: {
       sec_user_id: 1,
       first_name: 'Ada',
@@ -93,6 +100,24 @@ describe('GreenChecksService', () => {
     resultId: 50,
   };
 
+  /** prepareEmail → prepareDataToEmail exige promesas en repositorio / plantilla. */
+  const stubNonOicrEmailData = () => {
+    getDataForReviseResult.mockResolvedValue({
+      sub_email: 'sub@test.com',
+      rev_email: 'rev@test.com',
+    });
+    getTemplate.mockResolvedValue(Buffer.from('<email/>'));
+  };
+
+  const stubOicrEmailData = () => {
+    oircData.mockResolvedValue({
+      requester_by_email: 'req@test.com',
+      reviewed_by_email: 'rev@test.com',
+      mel_expert_email: 'mel@test.com',
+    });
+    getTemplate.mockResolvedValue(Buffer.from('<email/>'));
+  };
+
   const setupTransactionForSaveHistory = () => {
     submissionHistoryRepo.insert.mockResolvedValue({
       identifiers: [{ submission_history_id: 77 }],
@@ -117,6 +142,9 @@ describe('GreenChecksService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    Object.assign(mockCurrentUser, {
+      roles: [SecRolesEnum.SUP_ADMIN],
+    });
     Object.assign(resultsUtilStub, {
       statusId: ResultStatusEnum.SUBMITTED,
       indicatorId: IndicatorsEnum.KNOWLEDGE_PRODUCT,
@@ -249,6 +277,280 @@ describe('GreenChecksService', () => {
       expect(res).toMatchObject({ submission_history_id: 77 });
       expect(sendEmail).not.toHaveBeenCalled();
     });
+
+    it('should return snapshot when transitioning to APPROVED', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.APPROVED,
+      });
+      resultsUtilStub.statusId = ResultStatusEnum.SUBMITTED;
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      setupTransactionForSaveHistory();
+      stubNonOicrEmailData();
+      const snapshot = {
+        result_id: 99,
+        result_status_id: ResultStatusEnum.APPROVED,
+      } as Result;
+      createSnapshot.mockResolvedValue(snapshot);
+
+      const res = await service.statusManagement(
+        99,
+        ResultStatusEnum.APPROVED,
+        'ok',
+      );
+
+      expect(createSnapshot).toHaveBeenCalledWith(1001, 2024);
+      expect(res).toEqual(snapshot);
+    });
+
+    it('should call validateOicrInternalCode when OICR moves from REQUESTED to DRAFT', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.DRAFT,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.REQUESTED;
+      resultsUtilStub.resultId = 50;
+      setupTransactionForSaveHistory();
+      stubOicrEmailData();
+      const body = {
+        mel_regional_expert: '1',
+        oicr_internal_code: 'OICR-1',
+        sharepoint_link: 'https://share.example/doc',
+      };
+
+      await service.statusManagement(50, ResultStatusEnum.DRAFT, 'c', body);
+
+      expect(validateOicrInternalCode).toHaveBeenCalledWith(50, 'OICR-1');
+    });
+
+    it('should call review when OICR moves from POSTPONE to DRAFT', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.DRAFT,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.POSTPONE;
+      setupTransactionForSaveHistory();
+      stubOicrEmailData();
+      const body = {
+        mel_regional_expert: '1',
+        oicr_internal_code: 'X',
+        sharepoint_link: 'https://share.example/doc',
+      };
+
+      await service.statusManagement(2, ResultStatusEnum.DRAFT, 'c', body);
+
+      expect(review).toHaveBeenCalledWith(50, body);
+    });
+
+    it('should reject OICR REQUESTED to DRAFT when required body fields are missing', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.DRAFT,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.REQUESTED;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(
+          2,
+          ResultStatusEnum.DRAFT,
+          'c',
+          {} as unknown as OptionalBody,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow OICR REQUESTED to DRAFT with required body fields', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.DRAFT,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.REQUESTED;
+      setupTransactionForSaveHistory();
+      stubOicrEmailData();
+
+      await service.statusManagement(2, ResultStatusEnum.DRAFT, 'c', {
+        mel_regional_expert: '1',
+        oicr_internal_code: 'OK',
+        sharepoint_link: 'https://share.example/doc',
+      });
+
+      expect(submissionHistoryRepo.insert).toHaveBeenCalled();
+    });
+
+    it('should reject REVISED without comment (non-OICR)', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.REVISED,
+      });
+      resultsUtilStub.statusId = ResultStatusEnum.SUBMITTED;
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.REVISED, ''),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should transition non-OICR SUBMITTED to REVISED with comment', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.REVISED,
+      });
+      resultsUtilStub.statusId = ResultStatusEnum.SUBMITTED;
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      setupTransactionForSaveHistory();
+      stubNonOicrEmailData();
+
+      const res = await service.statusManagement(
+        1,
+        ResultStatusEnum.REVISED,
+        'please fix',
+      );
+
+      expect(res).toMatchObject({ submission_history_id: 77 });
+    });
+
+    it('should reject unsupported target status (default branch)', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.EDITING,
+      });
+      resultsUtilStub.statusId = ResultStatusEnum.SUBMITTED;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.EDITING, 'x'),
+      ).rejects.toThrow('Invalid status');
+    });
+
+    it('should reject OICR_APPROVED when current status is not REQUESTED', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.OICR_APPROVED,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.DRAFT;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.OICR_APPROVED, 'x'),
+      ).rejects.toThrow('Only OIRC in requested status');
+    });
+
+    it('should allow OICR_APPROVED from REQUESTED', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.OICR_APPROVED,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.REQUESTED;
+      setupTransactionForSaveHistory();
+      stubOicrEmailData();
+
+      const res = await service.statusManagement(
+        1,
+        ResultStatusEnum.OICR_APPROVED,
+        'ok',
+      );
+
+      expect(res).toMatchObject({ submission_history_id: 77 });
+    });
+
+    it('should reject OICR transition to SCIENCE_EDITION from invalid prior status', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.SCIENCE_EDITION,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.SUBMITTED;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.SCIENCE_EDITION, 'x'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should allow OICR transition to SCIENCE_EDITION from DRAFT', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.SCIENCE_EDITION,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.DRAFT;
+      setupTransactionForSaveHistory();
+
+      const res = await service.statusManagement(
+        1,
+        ResultStatusEnum.SCIENCE_EDITION,
+        'x',
+      );
+
+      expect(res).toMatchObject({ submission_history_id: 77 });
+    });
+
+    it('should reject change when current is APPROVED and target is REVISED', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.REVISED,
+      });
+      resultsUtilStub.statusId = ResultStatusEnum.APPROVED;
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.REVISED, 'c'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should reject SUBMITTED to DRAFT without comment', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.DRAFT,
+      });
+      resultsUtilStub.statusId = ResultStatusEnum.SUBMITTED;
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.DRAFT),
+      ).rejects.toThrow('comment is required when changing from submitted');
+    });
+
+    it('should throw ForbiddenException when OICR POSTPONE lacks admin role', async () => {
+      mockCurrentUser.roles = [SecRolesEnum.CONTRIBUTOR];
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.POSTPONE,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.REQUESTED;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.POSTPONE, 'p'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow OICR REQUESTED to POSTPONE when user is admin', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.POSTPONE,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.REQUESTED;
+      setupTransactionForSaveHistory();
+      stubOicrEmailData();
+
+      const res = await service.statusManagement(
+        1,
+        ResultStatusEnum.POSTPONE,
+        'postpone reason',
+      );
+
+      expect(res).toMatchObject({ submission_history_id: 77 });
+    });
+
+    it('should reject OICR POSTPONE when current status is not in allowed list', async () => {
+      resultStatusRepo.findOne.mockResolvedValue({
+        result_status_id: ResultStatusEnum.POSTPONE,
+      });
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      resultsUtilStub.statusId = ResultStatusEnum.KM_CURATION;
+      setupTransactionForSaveHistory();
+
+      await expect(
+        service.statusManagement(1, ResultStatusEnum.POSTPONE, 'p'),
+      ).rejects.toThrow(/OIRC in requested status can be/);
+    });
   });
 
   describe('saveHistory', () => {
@@ -353,6 +655,32 @@ describe('GreenChecksService', () => {
         ResultStatusEnum.SUBMITTED,
       );
     });
+
+    it('should join owner and submitter emails when owner is not current user', async () => {
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      getDataForSubmissionResult.mockResolvedValue({
+        principal_investigator_first_name: 'P',
+        principal_investigator_last_name: 'I',
+        result_id: 20,
+        result_title: 'T',
+        project_name: 'Pr',
+        owner_id: 99,
+        owner_email: 'owner@test.com',
+        indicator: 'KP',
+      });
+      getTemplate.mockResolvedValue(Buffer.from('sub'));
+
+      const prepared = await service.prepareDataToEmail(
+        20,
+        ResultStatusEnum.SUBMITTED,
+        ResultStatusEnum.DRAFT,
+        TemplateEnum.SUBMITTED_RESULT,
+      );
+
+      expect(prepared.data).toMatchObject({
+        rev_email: 'owner@test.com, ada@test.com',
+      });
+    });
   });
 
   describe('prepareEmail', () => {
@@ -361,6 +689,26 @@ describe('GreenChecksService', () => {
         1,
         ResultStatusEnum.SCIENCE_EDITION,
         ResultStatusEnum.DRAFT,
+      );
+      expect(sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should skip when getTemplateByStatus returns null', async () => {
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      await service.prepareEmail(
+        5,
+        ResultStatusEnum.DRAFT,
+        ResultStatusEnum.SUBMITTED,
+      );
+      expect(sendEmail).not.toHaveBeenCalled();
+      expect(getDataForReviseResult).not.toHaveBeenCalled();
+    });
+
+    it('should exit early for DRAFT from SCIENCE_EDITION', async () => {
+      await service.prepareEmail(
+        1,
+        ResultStatusEnum.DRAFT,
+        ResultStatusEnum.SCIENCE_EDITION,
       );
       expect(sendEmail).not.toHaveBeenCalled();
     });
@@ -383,6 +731,84 @@ describe('GreenChecksService', () => {
         expect.objectContaining({
           to: 'sub@test.com',
           subject: expect.stringContaining('approved'),
+        }),
+      );
+    });
+
+    it('should send OICR email with MEL expert on cc when OICR_APPROVED', async () => {
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      oircData.mockResolvedValue({
+        requester_by_email: 'req@test.com',
+        reviewed_by_email: 'rev@test.com',
+        mel_expert_email: 'mel@test.com',
+      });
+      getTemplate.mockResolvedValue(Buffer.from('<oicr/>'));
+
+      await service.prepareEmail(
+        3,
+        ResultStatusEnum.OICR_APPROVED,
+        ResultStatusEnum.REQUESTED,
+        {
+          oicr_internal_code: 'N-1',
+          mel_regional_expert: '1',
+          sharepoint_link: 'https://share.example/doc',
+        },
+      );
+
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'req@test.com',
+          cc: 'rev@test.com,mel@test.com',
+        }),
+      );
+    });
+
+    it('should send OICR email without MEL on cc when not OICR_APPROVED', async () => {
+      resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
+      oircData.mockResolvedValue({
+        requester_by_email: 'req@test.com',
+        reviewed_by_email: 'rev@test.com',
+        mel_expert_email: 'mel@test.com',
+      });
+      getTemplate.mockResolvedValue(Buffer.from('<oicr/>'));
+
+      await service.prepareEmail(
+        3,
+        ResultStatusEnum.REJECTED,
+        ResultStatusEnum.REQUESTED,
+      );
+
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'req@test.com',
+          cc: 'rev@test.com',
+        }),
+      );
+    });
+
+    it('should send SUBMITTED email to current user when non-OICR', async () => {
+      resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+      getDataForSubmissionResult.mockResolvedValue({
+        principal_investigator_first_name: 'P',
+        principal_investigator_last_name: 'I',
+        result_id: 20,
+        result_title: 'T',
+        project_name: 'Pr',
+        owner_id: 1,
+        owner_email: 'owner@test.com',
+        indicator: 'KP',
+      });
+      getTemplate.mockResolvedValue(Buffer.from('<sub/>'));
+
+      await service.prepareEmail(
+        20,
+        ResultStatusEnum.SUBMITTED,
+        ResultStatusEnum.DRAFT,
+      );
+
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'ada@test.com',
         }),
       );
     });
@@ -458,6 +884,19 @@ describe('GreenChecksService', () => {
       );
       expect(submissionHistoryLogRepo.save).toHaveBeenCalled();
     });
+
+    it('should throw ConflictException when update fails', async () => {
+      submissionHistoryRepo.findOne.mockResolvedValue({
+        submission_history_id: 5,
+        result_id: 1,
+        custom_date: new Date('2020-01-01'),
+      });
+      submissionHistoryRepo.update.mockRejectedValueOnce(new Error('db'));
+
+      await expect(
+        service.updateChageStatusDate(1, 5, new Date('2025-06-01')),
+      ).rejects.toThrow(ConflictException);
+    });
   });
 
   describe('saveSubmissionHistoryLog', () => {
@@ -489,6 +928,21 @@ describe('GreenChecksService', () => {
           created_by: 1,
         }),
       );
+    });
+
+    it('should throw ConflictException when save fails', async () => {
+      submissionHistoryRepo.findOne.mockResolvedValue({
+        submission_history_id: 3,
+      });
+      submissionHistoryLogRepo.save.mockRejectedValueOnce(new Error('db'));
+
+      await expect(
+        service.saveSubmissionHistoryLog(
+          3,
+          new Date('2025-01-02'),
+          new Date('2025-01-01'),
+        ),
+      ).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/server/researchindicators/src/domain/entities/lever-sdg-targets/lever-sdg-targets.service.ts
+++ b/server/researchindicators/src/domain/entities/lever-sdg-targets/lever-sdg-targets.service.ts
@@ -106,9 +106,20 @@ export class LeverSdgTargetsService extends BaseServiceSimple<
           sdg_target: true,
         },
       },
+      where: {
+        is_active: true,
+      },
       relations: {
         lever: true,
         sdg_target: true,
+      },
+      order: {
+        lever: {
+          id: 'ASC',
+        },
+        sdg_target: {
+          sdg_target_code: 'ASC',
+        },
       },
     });
   }
@@ -139,6 +150,7 @@ export class LeverSdgTargetsService extends BaseServiceSimple<
         },
         where: {
           lever_id: leverId,
+          is_active: true,
         },
         relations: {
           sdg_target: {

--- a/server/researchindicators/src/domain/entities/results/results.controller.ts
+++ b/server/researchindicators/src/domain/entities/results/results.controller.ts
@@ -51,7 +51,7 @@ export class ResultsController {
   constructor(
     private readonly resultsService: ResultsService,
     private readonly _resultsUtil: ResultsUtil,
-  ) {}
+  ) { }
 
   @ApiQuery({
     name: 'page',
@@ -560,7 +560,7 @@ export class ResultsController {
 
   @ApiOperation({ summary: 'Create results from AI bulk' })
   @Post('ai/formalize/bulk')
-  @Roles(SecRolesEnum.DEVELOPER, SecRolesEnum.CENTER_ADMIN)
+  @Roles(SecRolesEnum.DEVELOPER, SecRolesEnum.GENERAL_ADMIN, SecRolesEnum.CENTER_ADMIN)
   @UsePipes(
     new ValidationPipe({
       whitelist: true,

--- a/server/researchindicators/src/domain/entities/results/results.controller.ts
+++ b/server/researchindicators/src/domain/entities/results/results.controller.ts
@@ -560,7 +560,7 @@ export class ResultsController {
 
   @ApiOperation({ summary: 'Create results from AI bulk' })
   @Post('ai/formalize/bulk')
-  @Roles(SecRolesEnum.DEVELOPER)
+  @Roles(SecRolesEnum.DEVELOPER, SecRolesEnum.CENTER_ADMIN)
   @UsePipes(
     new ValidationPipe({
       whitelist: true,

--- a/server/researchindicators/src/domain/entities/results/results.service.ts
+++ b/server/researchindicators/src/domain/entities/results/results.service.ts
@@ -134,7 +134,7 @@ export class ResultsService {
     private readonly _resultLeverSdgTargetsService: ResultLeverSdgTargetsService,
     private readonly _resultKnowledgeProductService: ResultKnowledgeProductService,
     private readonly _resultsUtil: ResultsUtil,
-  ) { }
+  ) {}
 
   async findResults(filters: Partial<ResultFiltersInterface>) {
     return this.mainRepo.findResultsFilters({
@@ -676,21 +676,21 @@ export class ResultsService {
       const primaryLevers: Partial<ResultLever>[] =
         primary_levers?.length > 0
           ? primary_levers.map((el) => ({
-            lever_id: el.lever_id,
-            is_primary: true,
-            result_lever_strategic_outcomes:
-              el?.result_lever_strategic_outcomes,
-            result_lever_sdg_targets: el?.result_lever_sdg_targets,
-          }))
+              lever_id: el.lever_id,
+              is_primary: true,
+              result_lever_strategic_outcomes:
+                el?.result_lever_strategic_outcomes,
+              result_lever_sdg_targets: el?.result_lever_sdg_targets,
+            }))
           : [];
 
       const contributorLevers: Partial<ResultLever>[] =
         contributor_levers?.length > 0
           ? contributor_levers.map((el) => ({
-            lever_id: el.lever_id,
-            is_primary: false,
-            result_lever_sdg_targets: el?.result_lever_sdg_targets,
-          }))
+              lever_id: el.lever_id,
+              is_primary: false,
+              result_lever_sdg_targets: el?.result_lever_sdg_targets,
+            }))
           : [];
 
       const fullLevers = filterByUniqueKeyWithPriority<Partial<ResultLever>>(
@@ -1248,8 +1248,8 @@ export class ResultsService {
         (country) => {
           country.result_countries_sub_nationals = country?.is_active
             ? saveGeoLocationDto.countries.find(
-              (el) => el.isoAlpha2 === country.isoAlpha2,
-            )?.result_countries_sub_nationals
+                (el) => el.isoAlpha2 === country.isoAlpha2,
+              )?.result_countries_sub_nationals
             : [];
           return country;
         },

--- a/server/researchindicators/src/domain/shared/enum/sec_role.enum.ts
+++ b/server/researchindicators/src/domain/shared/enum/sec_role.enum.ts
@@ -8,4 +8,5 @@ export enum SecRolesEnum {
   DEVELOPER = 7,
   TESTER = 8,
   GENERAL_ADMIN = 9,
+  CENTER_ADMIN = 10,
 }

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.controller.spec.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.controller.spec.ts
@@ -1,19 +1,50 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
 import { ClarisaSdgTargetsController } from './clarisa-sdg-targets.controller';
 import { ClarisaSdgTargetsService } from './clarisa-sdg-targets.service';
+import { ResponseUtils } from '../../../../shared/utils/response.utils';
+
+jest.mock('../../../../shared/utils/response.utils');
 
 describe('ClarisaSdgTargetsController', () => {
   let controller: ClarisaSdgTargetsController;
+  const mockFindAll = jest.fn();
+  const mockFormat = jest.fn();
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    (ResponseUtils.format as jest.Mock) = mockFormat;
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ClarisaSdgTargetsController],
-      providers: [{ provide: ClarisaSdgTargetsService, useValue: {} }],
+      providers: [
+        { provide: ClarisaSdgTargetsService, useValue: { findAll: mockFindAll } },
+      ],
     }).compile();
     controller = module.get(ClarisaSdgTargetsController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('findAll returns formatted service response', async () => {
+    const rows = [{ id: 1n, sdg_target_code: '1.1' }];
+    mockFindAll.mockResolvedValue(rows);
+    const formatted = {
+      description: 'SDG Targets found',
+      status: HttpStatus.OK,
+      data: rows,
+    };
+    mockFormat.mockReturnValue(formatted);
+
+    const result = await controller.findAll();
+
+    expect(mockFindAll).toHaveBeenCalledWith();
+    expect(ResponseUtils.format).toHaveBeenCalledWith({
+      data: rows,
+      description: 'SDG Targets found',
+      status: HttpStatus.OK,
+    });
+    expect(result).toBe(formatted);
   });
 });

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.controller.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.controller.ts
@@ -1,7 +1,22 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpStatus } from '@nestjs/common';
 import { ClarisaSdgTargetsService } from './clarisa-sdg-targets.service';
+import { ResponseUtils } from '../../../../shared/utils/response.utils';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
-@Controller('sdg-targets')
+@ApiTags('Clarisa')
+@Controller()
+@ApiBearerAuth()
 export class ClarisaSdgTargetsController {
-  constructor(private readonly sdgTargetsService: ClarisaSdgTargetsService) {}
+  constructor(private readonly sdgTargetsService: ClarisaSdgTargetsService) { }
+
+  @Get()
+  async findAll() {
+    return this.sdgTargetsService.findAll().then((data) =>
+      ResponseUtils.format({
+        data: data,
+        description: 'SDG Targets found',
+        status: HttpStatus.OK,
+      }),
+    );
+  }
 }

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.module.spec.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.module.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClarisaSdgTargetsModule } from './clarisa-sdg-targets.module';
+import { ClarisaSdgTargetsController } from './clarisa-sdg-targets.controller';
+import { ClarisaSdgTargetsService } from './clarisa-sdg-targets.service';
+
+describe('ClarisaSdgTargetsModule', () => {
+  it('compiles and exposes controller with service overridden', async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [ClarisaSdgTargetsModule],
+    })
+      .overrideProvider(ClarisaSdgTargetsService)
+      .useValue({ findAll: jest.fn() })
+      .compile();
+
+    expect(moduleRef.get(ClarisaSdgTargetsController)).toBeInstanceOf(
+      ClarisaSdgTargetsController,
+    );
+  });
+});

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.service.spec.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.service.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource, FindOptionsRelations, FindOptionsWhere } from 'typeorm';
+import { ClarisaSdgTargetsService } from './clarisa-sdg-targets.service';
+import { CurrentUserUtil } from '../../../../shared/utils/current-user.util';
+import { AppConfig } from '../../../../shared/utils/app-config.util';
+import { ClarisaSdgTarget } from './entities/clarisa-sdg-target.entity';
+
+describe('ClarisaSdgTargetsService', () => {
+  let service: ClarisaSdgTargetsService;
+  const mockFind = jest.fn();
+  const mockGetRepository = jest.fn();
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGetRepository.mockReturnValue({
+      find: mockFind,
+      findOne: jest.fn(),
+      metadata: {
+        primaryColumns: [{ propertyName: 'id' }],
+        columns: [],
+        relations: [],
+      },
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClarisaSdgTargetsService,
+        {
+          provide: DataSource,
+          useValue: { getRepository: mockGetRepository },
+        },
+        { provide: CurrentUserUtil, useValue: {} },
+        { provide: AppConfig, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(ClarisaSdgTargetsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('registers ClarisaSdgTarget repository with sdg_target_code as find-by-name key', () => {
+    expect(mockGetRepository).toHaveBeenCalledWith(ClarisaSdgTarget);
+  });
+
+  it('findAll delegates to repository with active default where', async () => {
+    mockFind.mockResolvedValue([]);
+    await service.findAll();
+    expect(mockFind).toHaveBeenCalledWith({
+      where: { is_active: true },
+      relations: {},
+    });
+  });
+
+  it('findAll passes relations and where when provided', async () => {
+    mockFind.mockResolvedValue([]);
+    const relations: FindOptionsRelations<ClarisaSdgTarget> = {
+      clarisa_sdg: true,
+    };
+    const where: FindOptionsWhere<ClarisaSdgTarget> = {
+      is_active: true,
+      id: 5,
+    };
+    await service.findAll(relations, where);
+    expect(mockFind).toHaveBeenCalledWith({
+      where,
+      relations,
+    });
+  });
+});

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.service.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/clarisa-sdg-targets.service.ts
@@ -1,11 +1,25 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { CurrentUserUtil } from '../../../../shared/utils/current-user.util';
+import { ControlListBaseService } from '../../../../shared/global-dto/clarisa-base-service';
+import { ClarisaSdgTarget } from './entities/clarisa-sdg-target.entity';
+import { AppConfig } from '../../../../shared/utils/app-config.util';
 
 @Injectable()
-export class ClarisaSdgTargetsService {
+export class ClarisaSdgTargetsService extends ControlListBaseService<
+  ClarisaSdgTarget,
+  Repository<ClarisaSdgTarget>
+> {
   constructor(
-    private readonly dataSource: DataSource,
-    private readonly currentUser: CurrentUserUtil,
-  ) {}
+    dataSource: DataSource,
+    currentUser: CurrentUserUtil,
+    private readonly appConfig: AppConfig,
+  ) {
+    super(
+      ClarisaSdgTarget,
+      dataSource.getRepository(ClarisaSdgTarget),
+      currentUser,
+      'sdg_target_code',
+    );
+  }
 }

--- a/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/entities/clarisa-sdg-target.entity.spec.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/entities/clarisa-sdg-targets/entities/clarisa-sdg-target.entity.spec.ts
@@ -1,0 +1,8 @@
+import { ClarisaSdgTarget } from './clarisa-sdg-target.entity';
+
+describe('ClarisaSdgTarget', () => {
+  it('entity metadata is loadable', () => {
+    expect(ClarisaSdgTarget).toBeDefined();
+    expect(ClarisaSdgTarget.name).toBe('ClarisaSdgTarget');
+  });
+});

--- a/server/researchindicators/src/domain/tools/clarisa/routes/clarisa.routes.ts
+++ b/server/researchindicators/src/domain/tools/clarisa/routes/clarisa.routes.ts
@@ -16,8 +16,13 @@ import { ClarisaSdgsModule } from '../entities/clarisa-sdgs/clarisa-sdgs.module'
 import { ClarisaInitiativesModule } from '../entities/clarisa-initiatives/clarisa-initiatives.module';
 import { ClarisaImpactAreasModule } from '../entities/clarisa-impact-areas/clarisa-impact-areas.module';
 import { ClarisaGlobalTargetsModule } from '../entities/clarisa-global-targets/clarisa-global-targets.module';
+import { ClarisaSdgTargetsModule } from '../entities/clarisa-sdg-targets/clarisa-sdg-targets.module';
 
 export const clarisaRoutes: Routes = [
+  {
+    path: 'sdg-targets',
+    module: ClarisaSdgTargetsModule,
+  },
   {
     path: 'initiatives',
     module: ClarisaInitiativesModule,


### PR DESCRIPTION
## Summary

This PR extends role-based access for AI bulk results creation, exposes formatted CLARISA SDG targets, improves lever–SDG target retrieval with filtering and deterministic ordering, and tightens the test suite and coverage configuration.

## Changes

### Results – AI bulk creation roles

- Allow `CENTER_ADMIN` to perform AI bulk results creation (results service).
- Extend allowed roles to include `GENERAL_ADMIN` (results controller).
- Minor code formatting cleanup in the touched results files.

### CLARISA SDG targets

- Implement `findAll` on `ClarisaSdgTargetsController` to return SDG targets in a consistent, formatted shape.
- Add/adjust unit tests for coverage and reliability.

### Lever SDG targets

- In `LeverSdgTargetsService`, filter to **active** SDG targets only.
- Order results by **lever ID** and **SDG target code** for predictable API behavior.

### Tests & coverage

- Update Jest `collectCoverageFrom` in `package.json` to exclude migration and enum files from coverage metrics.
- Strengthen `GreenChecksService` tests with additional role scenarios and email-related stubs.

### Other

- Includes merge of branch `AC-1552-Embedding-Bulk-Upload-App-in-STAR-Admin-Module-with-Role-Based-Access` into `staging` (`5fc97f56`).

## How to test

- Run unit tests: `npm test` (from `server/researchindicators` if that is your app root).
- Optionally run coverage: `npm run test:cov` and confirm expectations for excluded paths.
- Manually verify (if applicable): CLARISA SDG targets `findAll`, lever SDG targets listing/order, and AI bulk results creation with `CENTER_ADMIN` and `GENERAL_ADMIN` users.

## Notes / risk

- Role changes affect who can trigger AI bulk results creation; confirm with product/security that `CENTER_ADMIN` and `GENERAL_ADMIN` are intended.
- Coverage percentages may shift after excluding migrations and enums from `collectCoverageFrom`.