### PR TITLE
Enhance result queries and add contract fields for improved retrieval

### DIFF
--- a/server/researchindicators/src/domain/entities/agresso-contract/agresso-contract.controller.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/agresso-contract.controller.ts
@@ -190,7 +190,8 @@ export class AgressoContractController {
     name: 'order-field',
     required: false,
     enum: OrderFieldsEnum,
-    description: 'Field to order by',
+    description:
+      'Field to order by (count-results = total active results per contract)',
   })
   @ApiQuery({
     name: 'direction',

--- a/server/researchindicators/src/domain/entities/agresso-contract/dto/mapper-agresso-contract.dto.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/dto/mapper-agresso-contract.dto.ts
@@ -12,6 +12,8 @@ export class RawgressoContractDto {
   public endDateGlobal: Date;
   public endDatefinance: Date;
   public contract_status: string;
+  /** Distinct active results for the contract (same basis as count-results sort). */
+  public contract_total_results?: number | string;
   public count_results: number;
   public indicator_id: number;
   public lever_id: string;
@@ -97,7 +99,11 @@ export class MappedContractsDto {
     this.endDateGlobal = rawData.endDateGlobal;
     this.endDatefinance = rawData.endDatefinance;
     this.contract_status = rawData.contract_status;
-    this.count_results = rawData.count_results;
+    this.count_results =
+      rawData.contract_total_results != null &&
+      rawData.contract_total_results !== ''
+        ? Number(rawData.contract_total_results)
+        : Number(rawData.count_results) || 0;
     this.is_science_program = Boolean(rawData.is_science_program);
     this.funding_type = rawData.funding_type;
     this.ubwClientDescription = rawData.ubwClientDescription;

--- a/server/researchindicators/src/domain/entities/agresso-contract/enum/order-fields.enum.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/enum/order-fields.enum.ts
@@ -9,4 +9,5 @@ export enum OrderFieldsEnum {
   STATUS = 'status',
   LEAD_CENTER = 'lead-center',
   LEVER = 'lever',
+  COUNT_RESULTS = 'count-results',
 }

--- a/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.spec.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.spec.ts
@@ -482,6 +482,10 @@ describe('AgressoContractRepository', () => {
           field: OrderFieldsEnum.LEVER,
           expected: 'cl.id ASC ',
         },
+        {
+          field: OrderFieldsEnum.COUNT_RESULTS,
+          expected: '_order_result_count ASC ',
+        },
       ];
       testCases.forEach(({ field, expected }) => {
         const direction = expected.includes('DESC') ? 'DESC' : 'ASC';

--- a/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.spec.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.spec.ts
@@ -484,7 +484,7 @@ describe('AgressoContractRepository', () => {
         },
         {
           field: OrderFieldsEnum.COUNT_RESULTS,
-          expected: '_order_result_count ASC ',
+          expected: 'contract_total_results ASC ',
         },
       ];
       testCases.forEach(({ field, expected }) => {

--- a/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
@@ -250,7 +250,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
   }
 
   /**
-   * Active distinct results per contract; matches the result_counts join logic in getContracts.
+   * Distinct active results per contract; used for contract-level count_results and count-results sort.
    */
   private buildContractTotalResultsCountSql(user?: User): string {
     const userFilter = user?.sec_user_id
@@ -280,7 +280,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
       [OrderFieldsEnum.STATUS]: 'ac.contract_status',
       [OrderFieldsEnum.LEAD_CENTER]: 'ac.ubwClientDescription',
       [OrderFieldsEnum.LEVER]: 'cl.id',
-      [OrderFieldsEnum.COUNT_RESULTS]: '_order_result_count',
+      [OrderFieldsEnum.COUNT_RESULTS]: 'contract_total_results',
     };
     return `${fieldMap[field] || 'ac.start_date'} ${direction} `;
   }
@@ -331,10 +331,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
 
     const dateFilterClause = this.buildDateFilterClause(filter);
     const indicators = await this.dataSource.getRepository(Indicator).find();
-    const orderByResultCountSelectSql =
-      orderFields === OrderFieldsEnum.COUNT_RESULTS
-        ? `, (${this.buildContractTotalResultsCountSql(user)}) AS _order_result_count`
-        : '';
+    const contractTotalResultsSelectSql = `, (${this.buildContractTotalResultsCountSql(user)}) AS contract_total_results`;
 
     const operationOrder = isEmpty(orderFields)
       ? `FIELD(ifnull(ac.contract_status, 'non'), 'ongoing', 'completed', 'suspended', 'discontinued', 'non')`
@@ -402,6 +399,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
         paginated_contracts.endDateGlobal,
         paginated_contracts.endDatefinance,
         paginated_contracts.contract_status,
+        paginated_contracts.contract_total_results,
         result_counts.indicator_id,
         COALESCE(result_counts.total_results, 0) as count_results,
         paginated_contracts.lever_id,
@@ -434,7 +432,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
                 ELSE ac.ubwClientDescription
             END AS ubwClientDescription
             ${queryRelevanceSelectSql}
-            ${orderByResultCountSelectSql}
+            ${contractTotalResultsSelectSql}
         FROM agresso_contracts ac
         LEFT JOIN clarisa_levers cl ON cl.short_name = CONCAT('Lever ', 
             IF(ac.departmentId LIKE 'L%', SUBSTRING(ac.departmentId, 2), NULL))

--- a/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
@@ -42,15 +42,14 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
     );
     const whereClause = filterWhere.length
       ? `WHERE ${filterWhere
-          .map(([key, value]) => `ac.${key} like '%${value}%'`)
-          .join(' AND ')}`
+        .map(([key, value]) => `ac.${key} like '%${value}%'`)
+        .join(' AND ')}`
       : '';
     const query = `
     select ac.*,
     ifnull(cl.full_name, 'Not available' ) as lever,
     cl.id as lever_id
-    ${
-      relations?.countries
+    ${relations?.countries
         ? `,JSON_ARRAYAGG(
             JSON_OBJECT(
                 'agreement_id', acc.agreement_id,
@@ -59,7 +58,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
             )
         ) AS countries`
         : ''
-    }
+      }
     from agresso_contracts ac 
     LEFT JOIN 
         agresso_contract_countries acc ON ac.agreement_id = acc.agreement_id
@@ -250,6 +249,23 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
     return parts.join(' + ');
   }
 
+  /**
+   * Active distinct results per contract; matches the result_counts join logic in getContracts.
+   */
+  private buildContractTotalResultsCountSql(user?: User): string {
+    const userFilter = user?.sec_user_id
+      ? `AND r_ord.created_by = ${user.sec_user_id}`
+      : '';
+    return `(SELECT COUNT(DISTINCT r_ord.result_id)
+        FROM results r_ord
+        INNER JOIN result_contracts rc_ord ON rc_ord.result_id = r_ord.result_id
+        WHERE rc_ord.contract_id = ac.agreement_id
+          AND r_ord.is_active = 1
+          AND r_ord.is_snapshot = FALSE
+          AND rc_ord.is_active = 1
+          ${userFilter})`;
+  }
+
   orderBy(field: string, direction: 'ASC' | 'DESC' = 'ASC'): string {
     if (isEmpty(field)) return '';
 
@@ -264,6 +280,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
       [OrderFieldsEnum.STATUS]: 'ac.contract_status',
       [OrderFieldsEnum.LEAD_CENTER]: 'ac.ubwClientDescription',
       [OrderFieldsEnum.LEVER]: 'cl.id',
+      [OrderFieldsEnum.COUNT_RESULTS]: '_order_result_count',
     };
     return `${fieldMap[field] || 'ac.start_date'} ${direction} `;
   }
@@ -314,6 +331,11 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
 
     const dateFilterClause = this.buildDateFilterClause(filter);
     const indicators = await this.dataSource.getRepository(Indicator).find();
+    const orderByResultCountSelectSql =
+      orderFields === OrderFieldsEnum.COUNT_RESULTS
+        ? `, (${this.buildContractTotalResultsCountSql(user)}) AS _order_result_count`
+        : '';
+
     const operationOrder = isEmpty(orderFields)
       ? `FIELD(ifnull(ac.contract_status, 'non'), 'ongoing', 'completed', 'suspended', 'discontinued', 'non')`
       : this.orderBy(orderFields, direction);
@@ -381,7 +403,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
         paginated_contracts.endDatefinance,
         paginated_contracts.contract_status,
         result_counts.indicator_id,
-        result_counts.total_results as count_results,
+        COALESCE(result_counts.total_results, 0) as count_results,
         paginated_contracts.lever_id,
         paginated_contracts.lever_short_name,
         paginated_contracts.lever_full_name,
@@ -412,6 +434,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
                 ELSE ac.ubwClientDescription
             END AS ubwClientDescription
             ${queryRelevanceSelectSql}
+            ${orderByResultCountSelectSql}
         FROM agresso_contracts ac
         LEFT JOIN clarisa_levers cl ON cl.short_name = CONCAT('Lever ', 
             IF(ac.departmentId LIKE 'L%', SUBSTRING(ac.departmentId, 2), NULL))

--- a/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
@@ -462,6 +462,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
         WHERE r.is_active = 1 
           AND r.is_snapshot = FALSE 
           AND rc.is_active = 1
+          AND rc.is_primary = TRUE
           ${user?.sec_user_id ? `AND r.created_by = ${user?.sec_user_id}` : ''}
         GROUP BY rc.contract_id, r.indicator_id
         HAVING COUNT(r.result_id) > 0 

--- a/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
+++ b/server/researchindicators/src/domain/entities/agresso-contract/repositories/agresso-contract.repository.ts
@@ -263,6 +263,7 @@ export class AgressoContractRepository extends Repository<AgressoContract> {
           AND r_ord.is_active = 1
           AND r_ord.is_snapshot = FALSE
           AND rc_ord.is_active = 1
+          AND rc_ord.is_primary = TRUE
           ${userFilter})`;
   }
 

--- a/server/researchindicators/src/domain/entities/results/enum/result-sort.enum.ts
+++ b/server/researchindicators/src/domain/entities/results/enum/result-sort.enum.ts
@@ -13,6 +13,7 @@ export const ResultSortFields = (
     status: 'rs.name',
     indicator: 'i.name',
     'result-title': 'r.title',
+    'last-updated': 'r.updated_at',
   };
 
   return fieldMap?.[field] ?? 'r.result_official_code';
@@ -29,4 +30,5 @@ export enum ResultSortEnum {
   STATUS = 'status',
   INDICATOR = 'indicator',
   RESULT_TITLE = 'result-title',
+  LAST_UPDATED = 'last-updated',
 }

--- a/server/researchindicators/src/domain/entities/results/repositories/result.repository.ts
+++ b/server/researchindicators/src/domain/entities/results/repositories/result.repository.ts
@@ -762,6 +762,7 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
     LEFT JOIN result_contracts rc on rc.result_id = r.result_id 
       AND rc.is_active 
       AND rc.is_primary 
+    LEFT JOIN agresso_contracts ac ON ac.agreement_id = rc.contract_id
     LEFT JOIN result_levers rl ON rl.result_id = r.result_id
       AND rl.is_active = TRUE
       AND rl.is_primary = TRUE
@@ -799,6 +800,7 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       rs.config as status_config,
       GROUP_CONCAT(DISTINCT r2.report_year_id ORDER BY r2.report_year_id DESC) AS snapshot_years,
       rc.contract_id,
+      ac.description as contract_description,
       cl.short_name as lever_name,
       su.sec_user_id as create_user_id,
       su.first_name as create_user_first_name,

--- a/server/researchindicators/src/domain/entities/results/results.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/results/results.service.spec.ts
@@ -5,7 +5,9 @@ import {
   HttpStatus,
   NotFoundException,
 } from '@nestjs/common';
-import { DataSource, EntityManager, Not } from 'typeorm';
+import { DataSource, EntityManager, In, Not } from 'typeorm';
+import { ResultContract } from '../result-contracts/entities/result-contract.entity';
+import { ResultLever } from '../result-levers/entities/result-lever.entity';
 import { ResultsService } from './results.service';
 import { ResultRepository } from './repositories/result.repository';
 import { ResultContractsService } from '../result-contracts/result-contracts.service';
@@ -2521,24 +2523,153 @@ describe('ResultsService', () => {
   });
 
   describe('findLastUpdatedResultByCurrentUser', () => {
-    it('should call mainRepo.find and return results', async () => {
-      // Arrange
+    it('should load primary contracts and levers and merge them per result', async () => {
       const take = 5;
       const mockResults = [
-        { result_id: 1, title: 'Result 1', updated_at: new Date() },
-        { result_id: 2, title: 'Result 2', updated_at: new Date() },
+        {
+          result_id: 1,
+          title: 'R1',
+          updated_at: new Date(),
+          public_link: 'https://a',
+          report_year_id: 2024,
+        },
+        {
+          result_id: 2,
+          title: 'R2',
+          updated_at: new Date(),
+          public_link: null,
+          report_year_id: 2025,
+        },
       ];
+      const contractFor1 = {
+        result_id: 1,
+        is_primary: true,
+        is_active: true,
+        agresso_contract: { id: 10 },
+      };
+      const leverFor1a = {
+        result_id: 1,
+        is_primary: true,
+        is_active: true,
+        lever: { lever_id: 100 },
+      };
+      const leverFor1b = {
+        result_id: 1,
+        is_primary: true,
+        is_active: true,
+        lever: { lever_id: 101 },
+      };
+      const leverFor2 = {
+        result_id: 2,
+        is_primary: true,
+        is_active: true,
+        lever: { lever_id: 200 },
+      };
 
-      // Mock the method directly
-      jest
-        .spyOn(service, 'findLastUpdatedResultByCurrentUser')
-        .mockResolvedValue(mockResults as any);
+      mockMainRepo.find.mockResolvedValue(mockResults as any);
 
-      // Act
+      const mockContractFind = jest.fn().mockResolvedValue([contractFor1]);
+      const mockLeverFind = jest
+        .fn()
+        .mockResolvedValue([leverFor1a, leverFor1b, leverFor2]);
+
+      mockDataSource.getRepository.mockImplementation((entity: unknown) => {
+        if (entity === ResultContract) {
+          return { find: mockContractFind } as any;
+        }
+        if (entity === ResultLever) {
+          return { find: mockLeverFind } as any;
+        }
+        return { find: jest.fn() } as any;
+      });
+
       const result = await service.findLastUpdatedResultByCurrentUser(take);
 
-      // Assert
-      expect(result).toEqual(mockResults);
+      expect(mockMainRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.arrayContaining([
+            'public_link',
+            'report_year_id',
+            'platform_code',
+          ]),
+          where: {
+            created_by: mockCurrentUser.user_id,
+            is_active: true,
+            is_snapshot: false,
+          },
+          relations: {
+            indicator: true,
+            result_status: true,
+          },
+          order: { updated_at: 'DESC' },
+          take,
+        }),
+      );
+
+      expect(mockContractFind).toHaveBeenCalledWith({
+        where: {
+          result_id: In([1, 2]),
+          is_primary: true,
+          is_active: true,
+        },
+        relations: { agresso_contract: true },
+      });
+      expect(mockLeverFind).toHaveBeenCalledWith({
+        where: {
+          result_id: In([1, 2]),
+          is_primary: true,
+          is_active: true,
+        },
+        relations: { lever: true },
+      });
+
+      expect(result).toEqual([
+        {
+          ...mockResults[0],
+          result_contracts: contractFor1,
+          result_levers: [leverFor1a, leverFor1b],
+        },
+        {
+          ...mockResults[1],
+          result_contracts: null,
+          result_levers: [leverFor2],
+        },
+      ]);
+    });
+
+    it('should return empty array when the user has no recent results', async () => {
+      mockMainRepo.find.mockResolvedValue([] as any);
+      const mockContractFind = jest.fn().mockResolvedValue([]);
+      const mockLeverFind = jest.fn().mockResolvedValue([]);
+      mockDataSource.getRepository.mockImplementation((entity: unknown) => {
+        if (entity === ResultContract) {
+          return { find: mockContractFind } as any;
+        }
+        if (entity === ResultLever) {
+          return { find: mockLeverFind } as any;
+        }
+        return { find: jest.fn() } as any;
+      });
+
+      const result = await service.findLastUpdatedResultByCurrentUser(10);
+
+      expect(result).toEqual([]);
+      expect(mockContractFind).toHaveBeenCalledWith({
+        where: {
+          result_id: In([]),
+          is_primary: true,
+          is_active: true,
+        },
+        relations: { agresso_contract: true },
+      });
+      expect(mockLeverFind).toHaveBeenCalledWith({
+        where: {
+          result_id: In([]),
+          is_primary: true,
+          is_active: true,
+        },
+        relations: { lever: true },
+      });
     });
   });
 

--- a/server/researchindicators/src/domain/entities/results/results.service.ts
+++ b/server/researchindicators/src/domain/entities/results/results.service.ts
@@ -1489,7 +1489,10 @@ export class ResultsService {
           'indicator',
           'result_status_id',
           'result_status',
-          'platform_code'
+          'platform_code',
+          'public_link',
+          'public_link',
+          'report_year_id'
         ],
         where: {
           created_by: this.currentUser.user_id,
@@ -1506,11 +1509,12 @@ export class ResultsService {
         take: take,
       })
       .then(async (results) => {
+        const resultIds = results.map((el) => el.result_id);
         const results_contract = await this.dataSource
           .getRepository(ResultContract)
           .find({
             where: {
-              result_id: In(results.map((el) => el.result_id)),
+              result_id: In(resultIds),
               is_primary: true,
               is_active: true,
             },
@@ -1519,13 +1523,30 @@ export class ResultsService {
             },
           });
 
+        const results_levers = await this.dataSource
+          .getRepository(ResultLever)
+          .find({
+            where: {
+              result_id: In(resultIds),
+              is_primary: true,
+              is_active: true,
+            },
+            relations: {
+              lever: true,
+            }
+          });
+
         return results.map((result) => {
           const contract = results_contract.find(
+            (el) => el.result_id === result.result_id,
+          );
+          const levers = results_levers.filter(
             (el) => el.result_id === result.result_id,
           );
           return {
             ...result,
             result_contracts: contract ?? null,
+            result_levers: levers ?? [],
           };
         });
       });


### PR DESCRIPTION
## Summary

This PR improves the STAR backend for **results** and **Agresso contracts**:

1. Enriches the **last updated results** endpoint with primary contracts and levers.
2. Adds **sort by last updated** and **contract description** in result list queries.
3. Improves **Agresso contracts**: per-contract result counts, sort by result count, and filtering on **primary** contracts only.

**Related work (from merge commits):**

- AC-1590 — Include the number of results in the projects table
- `fix-prms-results` — PRMS results fixes

---

## Changes by area

### 1. Results — `GET /results/last-updated/current-user`

**Before:** The response lacked enough context (project/contract, levers) for “recent results” UI widgets.

**After:** `findLastUpdatedResultByCurrentUser` now:

- Returns extra fields: `public_link`, `report_year_id`, `platform_code`.
- Batch-loads active primary contracts (`ResultContract` + `agresso_contract`).
- Batch-loads active primary levers (`ResultLever` + `lever`).

Per result:

| Field | Description |
|-------|-------------|
| `result_contracts` | Primary contract object, or `null` |
| `result_levers` | Array of primary levers (may be empty) |

**Example response shape (per item):**

```json
{
  "result_id": 1,
  "title": "...",
  "updated_at": "...",
  "public_link": "https://...",
  "report_year_id": 2024,
  "indicator": {},
  "result_status": {},
  "result_contracts": {
    "result_id": 1,
    "agresso_contract": {}
  },
  "result_levers": [{ "lever": { "lever_id": 100 } }]
}
```

---

### 2. Results — list endpoints with `sort-field`

**New sort option:**

| Query param | Enum value | SQL column |
|-------------|------------|------------|
| `sort-field` | `last-updated` | `r.updated_at` |

**Example:**

```http
GET /results/...?sort-field=last-updated&sort-order=DESC
```

**New field in repository SELECT:**

- `contract_description` — Agresso contract description for the result’s active primary `result_contract` (via `agresso_contracts` join).

---

### 3. Agresso contracts — `GET /agresso-contract/find-contracts`

#### 3.1 Per-contract result count (`contract_total_results`)

New subquery `buildContractTotalResultsCountSql`:

- `COUNT(DISTINCT result_id)` for active, non-snapshot results.
- Only **primary** contracts (`rc.is_primary = TRUE`, `rc.is_active = 1`).
- When a user context exists (`current-user`), filters by `created_by = sec_user_id`.

Exposed as `contract_total_results` in SQL; mapped to `count_results` in the API DTO (preferred over per-indicator counts).

#### 3.2 Sort by result count

| Query param | Value | Behavior |
|-------------|-------|----------|
| `order-field` | `count-results` | Order by `contract_total_results` |
| `direction` | `ASC` \| `DESC` | Sort direction |

Swagger description updated on the controller.

#### 3.3 Primary contract filter on aggregations

Indicator-level `GROUP BY` now includes:

```sql
AND rc.is_primary = TRUE
```

User-scoped joins in `getContracts` also restrict to active primary contracts, aligning “my projects” with each result’s main contract.

#### 3.4 DTO mapper

`MappedContractsDto.count_results` resolution order:

1. `contract_total_results` when present
2. Legacy `count_results` (per indicator)
3. Fallback `0`

---

## API impact

| Endpoint / parameter | Change type | Notes |
|----------------------|-------------|-------|
| `GET .../last-updated/current-user` | Extension | New fields; backward compatible if clients ignore unknown fields |
| `sort-field=last-updated` | New | Optional |
| Result list responses | Extension | New `contract_description` field |
| `GET .../find-contracts?order-field=count-results` | New | Optional |
| `count_results` on contracts | Semantic | May differ from per-indicator count; reflects primary-contract totals |

No endpoints or existing query parameters were removed.

---

## Commits included

| Commit | Description |
|--------|-------------|
| `90f16c3` | Enhance `findLastUpdatedResultByCurrentUser` with contracts and levers |
| `ccb094e` | Add `last-updated` sort and contract description in result queries |
| `78886d5` | Add `count-results` order option and query for active results per contract |
| `16448a8` | Introduce `contract_total_results` field and related query logic |
| `336ebc3` | Filter primary contracts for improved result accuracy |
| `9956c98` | Enhance query with primary contracts filter |
| `2442798` | Merge `AC-1590-Include-the-number-of-results-in-projects-table` into staging |
| `4a9fedd` | Merge `fix-prms-results` into staging |

---

## Files changed

| File | Main change |
|------|-------------|
| `results.service.ts` | Contracts + levers on last-updated results |
| `results.service.spec.ts` | Unit tests for new behavior |
| `result.repository.ts` | `contract_description` + `agresso_contracts` join |
| `result-sort.enum.ts` | `last-updated` sort field |
| `agresso-contract.repository.ts` | Subquery, ordering, `is_primary` filter |
| `mapper-agresso-contract.dto.ts` | `count_results` mapping |
| `order-fields.enum.ts` | `COUNT_RESULTS = 'count-results'` |
| `agresso-contract.controller.ts` | Swagger docs |
| `agresso-contract.repository.spec.ts` | `count-results` order test |

All paths are under `server/researchindicators/src/domain/entities/`.