### PR TITLE
OICR Backend Enhancements: CGSpace Link, Status Workflow, Admin Edit Permissions & STAR Export Fixes

### DIFF
--- a/server/researchindicators/src/db/migrations/1780074063394-AddedCGSpaceLink.ts
+++ b/server/researchindicators/src/db/migrations/1780074063394-AddedCGSpaceLink.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedCGSpaceLink1780074063394 implements MigrationInterface {
+  name = 'AddedCGSpaceLink1780074063394';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_oicrs\` ADD \`cgspace_link\` text NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_oicrs\` DROP COLUMN \`cgspace_link\``,
+    );
+  }
+}

--- a/server/researchindicators/src/db/migrations/1780331976405-AddedValidationColumn.ts
+++ b/server/researchindicators/src/db/migrations/1780331976405-AddedValidationColumn.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedValidationColumn1780331976405 implements MigrationInterface {
+  name = 'AddedValidationColumn1780331976405';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_status_workflow\` ADD \`is_status_change_validation_required\` tinyint NOT NULL DEFAULT 0`,
+    );
+    await queryRunner.query(
+      `UPDATE \`result_status_workflow\` SET \`is_status_change_validation_required\` = 1 WHERE id IN (1, 6, 7, 12, 13, 18, 19, 24, 25, 30, 37)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_status_workflow\` DROP COLUMN \`is_status_change_validation_required\``,
+    );
+  }
+}

--- a/server/researchindicators/src/db/migrations/1780342254980-AddedValidationGreenFunction.ts
+++ b/server/researchindicators/src/db/migrations/1780342254980-AddedValidationGreenFunction.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedValidationGreenFunction1780342254980
+    implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE \`result_status_workflow\` SET config = ? WHERE id = ?`,
+            [
+                JSON.stringify({
+                    actions: [
+                        {
+                            type: 'validation',
+                            config: { function_name: 'completenessValidation' },
+                            enabled: true,
+                        },
+                    ],
+                }),
+                37,
+            ],
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE \`result_status_workflow\` SET config = NULL WHERE id = ?`,
+            [37],
+        );
+    }
+}

--- a/server/researchindicators/src/db/migrations/1780519377343-UpdateOicrGreen.ts
+++ b/server/researchindicators/src/db/migrations/1780519377343-UpdateOicrGreen.ts
@@ -1,0 +1,277 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateOicrGreen1780519377343 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP FUNCTION IF EXISTS \`oicr_validation\`;`);
+        await queryRunner.query(`CREATE FUNCTION \`oicr_validation\`(result_code BIGINT) RETURNS tinyint(1)
+    READS SQL DATA
+BEGIN
+                                    DECLARE general_validation BOOLEAN DEFAULT FALSE;
+                                    
+                                    SELECT 
+                                        valid_text(ro.oicr_internal_code) AND
+                                        ro.maturity_level_id IS NOT NULL AND
+                                        valid_text(ro.outcome_impact_statement) AND
+                                        valid_text(ro.short_outcome_impact_statement)
+                                        INTO
+                                        general_validation
+                                    FROM result_oicrs ro 
+                                    WHERE ro.result_id = result_code;
+                                    
+                                    
+                                    SELECT 
+                                        COUNT(rt.id) > 0 AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM result_tags rt 
+                                    WHERE rt.is_active = TRUE
+                                        AND rt.result_id = result_code;
+                                                                                   
+                                    
+                                    SELECT 
+                                        COUNT( treo.id > 0) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM TEMP_result_external_oicrs treo 
+                                    WHERE treo.result_id = result_code
+                                        AND treo.is_active = TRUE;
+                                    
+                                    
+                                    SELECT 
+                                        IFNULL(COUNT(rq.id) = SUM(valid_text(rq.unit) AND 
+                                                            rq.quantification_number IS NOT NULL AND 
+                                                            valid_text(rq.description)), TRUE) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM result_quantifications rq 
+                                    WHERE rq.result_id = result_code
+                                        AND rq.is_active = TRUE
+                                        AND rq.quantification_role_id = 1;
+                                    
+                                    SELECT 
+                                        IFNULL(COUNT(rq.id) = SUM(valid_text(rq.unit) AND 
+                                                            rq.quantification_number IS NOT NULL AND 
+                                                            valid_text(rq.description)), TRUE) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM result_quantifications rq 
+                                    WHERE rq.result_id = result_code
+                                        AND rq.is_active = TRUE
+                                        AND rq.quantification_role_id = 2;
+                                    
+                                    SELECT 
+                                    	COUNT(cia.id) = SUM(ria.impact_area_score_id IS NOT NULL) AND general_validation
+                                    	INTO
+                                    	general_validation
+                                    FROM clarisa_impact_areas cia 	
+                                    	LEFT JOIN result_impact_areas ria ON ria.impact_area_id = cia.id 
+                                    									AND ria.is_active = TRUE
+                                    									AND ria.result_id = result_code;
+                                    
+                                    
+                                    SELECT 
+                                        count(temp.id) = COALESCE(COUNT(temp.valid), FALSE) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM (SELECT ria.id, SUM(riagt.id > 0) > 0 AS valid
+                                    FROM result_impact_areas ria
+                                    LEFT JOIN result_impact_area_global_target riagt ON riagt.result_impact_area_id = ria.id
+                                                                                    AND riagt.is_active = TRUE
+                                    WHERE ria.result_id = result_code
+                                        AND ria.impact_area_score_id = 3
+                                    GROUP BY ria.id) temp;
+                                    
+                                        
+                                    RETURN general_validation;     
+                                END;`);
+
+        await queryRunner.query(`DROP FUNCTION IF EXISTS \`evidences_validation\`;`);
+        await queryRunner.query(`CREATE FUNCTION \`evidences_validation\`(result_code BIGINT) RETURNS tinyint(1)
+    READS SQL DATA
+begin 
+            
+            declare temp_count_url int default 0;
+            declare temp_count_description int default 0;
+            declare temp_count_evidences int default 0;
+            declare reurn_validation boolean default false;
+            DECLARE current_indicator BIGINT DEFAULT NULL;
+
+            select 
+                count(re.result_evidence_id),
+                sum(valid_text(re.evidence_url)),
+                sum(valid_text(re.evidence_description))
+                into
+                temp_count_evidences,
+                temp_count_url,
+                temp_count_description
+            from result_evidences re 
+            where re.is_active = true
+                and re.evidence_role_id = 1
+                and re.result_id = result_code
+            group by re.result_id;
+            
+            SELECT 
+            	r.indicator_id 
+            	INTO 
+            	current_indicator
+            FROM results r
+            WHERE r.result_id = result_code
+            	AND r.is_active = TRUE;
+                
+            set reurn_validation = if( temp_count_evidences > 0 and temp_count_url = temp_count_description, true, false );
+
+            SELECT 
+                IFNULL(COUNT(rnr.id) = SUM(valid_text(rnr.link) AND 
+                                    rnr.notable_reference_type_id IS NOT NULL), TRUE) AND reurn_validation 
+                INTO
+                reurn_validation
+            FROM result_notable_references rnr 
+            WHERE rnr.is_active = TRUE
+                AND rnr.result_id = result_code;
+            
+            IF current_indicator = 5 THEN
+            
+            	SELECT 
+            		valid_text(ro.cgspace_link) AND reurn_validation
+            		INTO
+            		reurn_validation
+            	FROM result_oicrs ro 
+            	WHERE ro.result_id = result_code
+            		AND ro.is_active = TRUE;
+            	
+            	
+            END IF;
+            
+                
+            return reurn_validation;
+            
+        end;`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP FUNCTION IF EXISTS \`oicr_validation\`;`);
+        await queryRunner.query(`CREATE FUNCTION \`oicr_validation\`(result_code BIGINT) RETURNS tinyint(1)
+    READS SQL DATA
+BEGIN
+                                    DECLARE general_validation BOOLEAN DEFAULT FALSE;
+                                    
+                                    SELECT 
+                                        valid_text(ro.oicr_internal_code) AND
+                                        ro.maturity_level_id IS NOT NULL AND
+                                        valid_text(ro.outcome_impact_statement) AND
+                                        valid_text(ro.short_outcome_impact_statement)
+                                        INTO
+                                        general_validation
+                                    FROM result_oicrs ro 
+                                    WHERE ro.result_id = result_code;
+                                    
+                                    
+                                    SELECT 
+                                        COUNT(rt.id) > 0 AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM result_tags rt 
+                                    WHERE rt.is_active = TRUE
+                                        AND rt.result_id = result_code;
+                                                                                   
+                                    
+                                    SELECT 
+                                        COUNT( treo.id > 0) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM TEMP_result_external_oicrs treo 
+                                    WHERE treo.result_id = result_code
+                                        AND treo.is_active = TRUE;
+                                    
+                                    
+                                    SELECT 
+                                        IFNULL(COUNT(rq.id) = SUM(valid_text(rq.unit) AND 
+                                                            rq.quantification_number IS NOT NULL AND 
+                                                            valid_text(rq.description)), TRUE) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM result_quantifications rq 
+                                    WHERE rq.result_id = result_code
+                                        AND rq.is_active = TRUE
+                                        AND rq.quantification_role_id = 1;
+                                    
+                                    SELECT 
+                                        IFNULL(COUNT(rq.id) = SUM(valid_text(rq.unit) AND 
+                                                            rq.quantification_number IS NOT NULL AND 
+                                                            valid_text(rq.description)), TRUE) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM result_quantifications rq 
+                                    WHERE rq.result_id = result_code
+                                        AND rq.is_active = TRUE
+                                        AND rq.quantification_role_id = 2;
+                                    
+                                    SELECT 
+                                    	COUNT(cia.id) = SUM(ria.impact_area_score_id IS NOT NULL) AND general_validation
+                                    	INTO
+                                    	general_validation
+                                    FROM clarisa_impact_areas cia 	
+                                    	LEFT JOIN result_impact_areas ria ON ria.impact_area_id = cia.id 
+                                    									AND ria.is_active = TRUE
+                                    									AND ria.result_id = result_code;
+                                    
+                                    
+                                    SELECT 
+                                        count(temp.id) = COALESCE(SUM(temp.valid), FALSE) AND general_validation
+                                        INTO
+                                        general_validation
+                                    FROM (SELECT ria.id, COUNT(riagt.id > 0) AS valid
+                                    FROM result_impact_areas ria
+                                    LEFT JOIN result_impact_area_global_target riagt ON riagt.result_impact_area_id = ria.id
+                                                                                    AND riagt.is_active = TRUE
+                                    WHERE ria.result_id = result_code
+                                        AND ria.impact_area_score_id = 3
+                                    GROUP BY ria.id) temp;
+                                    
+                                        
+                                    RETURN general_validation;     
+                                END;`);
+
+        await queryRunner.query(`DROP FUNCTION IF EXISTS \`evidences_validation\`;`);
+        await queryRunner.query(`CREATE FUNCTION \`evidences_validation\`(result_code BIGINT) RETURNS tinyint(1)
+    READS SQL DATA
+begin 
+            
+            declare temp_count_url int default 0;
+            declare temp_count_description int default 0;
+            declare temp_count_evidences int default 0;
+            declare reurn_validation boolean default false;
+
+            select 
+                count(re.result_evidence_id),
+                sum(valid_text(re.evidence_url)),
+                sum(valid_text(re.evidence_description)) 
+                into
+                temp_count_evidences,
+                temp_count_url,
+                temp_count_description
+            from result_evidences re 
+            where re.is_active = true
+                and re.evidence_role_id = 1
+                and re.result_id = result_code
+            group by re.result_id;
+                
+            set reurn_validation = if( temp_count_evidences > 0 and temp_count_url = temp_count_description, true, false );
+
+            SELECT 
+                IFNULL(COUNT(rnr.id) = SUM(valid_text(rnr.link) AND 
+                                    rnr.notable_reference_type_id IS NOT NULL), TRUE) AND reurn_validation 
+                INTO
+                reurn_validation
+            FROM result_notable_references rnr 
+            WHERE rnr.is_active = TRUE
+                AND rnr.result_id = result_code;
+                
+            return reurn_validation;
+            
+        end`);
+
+    }
+
+}

--- a/server/researchindicators/src/db/migrations/1780590538118-UpdateOICRview.ts
+++ b/server/researchindicators/src/db/migrations/1780590538118-UpdateOICRview.ts
@@ -1,0 +1,158 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateOICRview1780590538118 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE OR REPLACE VIEW report_oicr AS
+SELECT
+	root.result_id,
+	report_field(ro.general_comment, TRUE, root.indicator_id = 5) general_comment,
+	report_field(ml.full_name , TRUE, root.indicator_id = 5) maturity_level,
+	report_field(ro.oicr_internal_code, TRUE, root.indicator_id = 5) oicr_internal_code,
+	report_field(ro.outcome_impact_statement, TRUE, root.indicator_id = 5) outcome_impact_statement,
+	report_field(ro.short_outcome_impact_statement, TRUE, root.indicator_id = 5) short_outcome_impact_statement,
+	report_field(ro.sharepoint_link, FALSE, root.indicator_id = 5) sharepoint_link,
+	report_field(CONCAT_WS('', aus.first_name, ' ', aus.last_name), TRUE, root.indicator_id = 5) mel_regional_expert,
+	report_field(rt.tag_name, TRUE , root.indicator_id = 5) tagging,
+	report_field(rq.quantifications, FALSE, root.indicator_id = 5) quantifications,
+	report_field(rq2.extrapolated_estimates , FALSE, root.indicator_id = 5) extrapolated_estimates,
+	report_field(acp.authors_contact_persons, FALSE, root.indicator_id = 5) authors_contact_persons,
+	report_field(IF(ro.for_external_use, 'YES', 'NO'), FALSE, root.indicator_id = 5) for_external_use,
+	report_field(ro.for_external_use_description, FALSE, root.indicator_id = 5) for_external_use_description,
+	report_field(ria.impact_area, TRUE, root.indicator_id = 5) impact_area,
+	report_field(treo.existing_oicr, TRUE, root.indicator_id = 5 AND rt.tag_id IN (2,3) AND rt.tag_id IS NOT NULL ) existing_oicr
+FROM results root
+	LEFT JOIN result_oicrs ro ON ro.result_id = root.result_id 
+	LEFT JOIN maturity_levels ml ON ml.id = ro.maturity_level_id 
+	LEFT JOIN alliance_user_staff_groups ausg ON ausg.staff_group_id  = ro.mel_staff_group_id 
+	LEFT JOIN alliance_user_staff aus ON aus.carnet = ausg.carnet 
+	LEFT JOIN (SELECT 
+					rt.result_id,
+					rt.tag_id,
+					t.name tag_name
+				FROM result_tags rt 
+					INNER JOIN tags t ON t.id = rt.tag_id 
+				WHERE rt.is_active = TRUE
+				GROUP BY rt.result_id
+				ORDER BY rt.result_id ASC) rt ON rt.result_id = root.result_id 
+	LEFT JOIN (SELECT 
+					rq.result_id,
+					GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') quantifications 
+				FROM result_quantifications rq 
+				WHERE rq.is_active = TRUE
+					AND rq.quantification_role_id = 1
+				GROUP BY rq.result_id) rq ON rq.result_id = root.result_id 
+	LEFT JOIN (SELECT 
+					rq.result_id,
+					GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') extrapolated_estimates 
+				FROM result_quantifications rq 
+				WHERE rq.is_active = TRUE
+					AND rq.quantification_role_id = 2
+				GROUP BY rq.result_id) rq2 ON rq2.result_id = root.result_id
+	LEFT JOIN (SELECT
+					ru.result_id,
+					GROUP_CONCAT(CONCAT_WS('','• ',aus.first_name, ' ', aus.last_name, ' - Position: ', IFNULL(aus.\`position\`, 'N/D'), ' - Affiliation: ', IFNULL(aus.center, 'N/D')) SEPARATOR '\n') authors_contact_persons
+				FROM result_users ru 
+					INNER JOIN alliance_user_staff aus ON aus.carnet = ru.user_id 
+				WHERE ru.user_role_id = 3
+					AND ru.is_active = TRUE
+				GROUP BY ru.result_id) acp ON acp.result_id = root.result_id 
+	LEFT JOIN (SELECT 
+					ria.result_id,
+					GROUP_CONCAT('• ', cia.name, ' - Score: ', report_field(CONCAT('(', ias.id - 1 ,') ', ias.name), TRUE, TRUE), '\n', rgt.global_targets   SEPARATOR '\n') impact_area
+				FROM result_impact_areas ria 
+					LEFT JOIN clarisa_impact_areas cia ON cia.id = ria.impact_area_id 
+					LEFT JOIN impact_area_scores ias ON ias.id = ria.impact_area_score_id 
+					LEFT JOIN (SELECT
+									riagt.result_impact_area_id,
+									GROUP_CONCAT('\t◦ ', cgt.smo_code, ' - ', cgt.target SEPARATOR '\n') global_targets
+								FROM result_impact_area_global_target riagt
+									LEFT JOIN clarisa_global_targets cgt ON cgt.targetId = riagt.global_target_id 
+								WHERE riagt.is_active = TRUE
+								GROUP BY riagt.result_impact_area_id) rgt ON rgt.result_impact_area_id = ria.id 
+				WHERE ria.is_active = TRUE
+				GROUP BY ria.result_id) ria ON ria.result_id = root.result_id 
+	LEFT JOIN (SELECT 
+					treo.result_id ,
+					CONCAT(teo.external_id, ' - ', teo.title) existing_oicr
+				FROM TEMP_result_external_oicrs treo 
+					INNER JOIN TEMP_external_oicrs teo on teo.id = treo.external_oicr_id 
+				WHERE treo.is_active = TRUE
+				GROUP BY treo.result_id) treo ON treo.result_id = root.result_id 
+WHERE root.is_active = TRUE
+	AND root.is_snapshot = FALSE
+ORDER BY root.result_id ASC; `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE OR REPLACE VIEW report_oicr AS
+            SELECT
+                root.result_id,
+                report_field(ro.general_comment, TRUE, root.indicator_id = 5) general_comment,
+                report_field(ml.full_name , TRUE, root.indicator_id = 5) maturity_level,
+                report_field(ro.oicr_internal_code, TRUE, root.indicator_id = 5) oicr_internal_code,
+                report_field(ro.outcome_impact_statement, TRUE, root.indicator_id = 5) outcome_impact_statement,
+                report_field(ro.short_outcome_impact_statement, TRUE, root.indicator_id = 5) short_outcome_impact_statement,
+                report_field(ro.sharepoint_link, FALSE, root.indicator_id = 5) sharepoint_link,
+                report_field(CONCAT_WS('', aus.first_name, ' ', aus.last_name), TRUE, root.indicator_id = 5) mel_regional_expert,
+                report_field(rt.tag_name, TRUE , root.indicator_id = 5) tagging,
+                report_field(rq.quantifications, FALSE, root.indicator_id = 5) quantifications,
+                report_field(rq2.extrapolated_estimates , FALSE, root.indicator_id = 5) extrapolated_estimates,
+                report_field(acp.authors_contact_persons, FALSE, root.indicator_id = 5) authors_contact_persons,
+                report_field(IF(ro.for_external_use, 'YES', 'NO'), FALSE, root.indicator_id = 5) for_external_use,
+                report_field(ro.for_external_use_description, FALSE, root.indicator_id = 5) for_external_use_description,
+                report_field(ria.impact_area, TRUE, root.indicator_id = 5) impact_area
+            FROM results root
+                LEFT JOIN result_oicrs ro ON ro.result_id = root.result_id 
+                LEFT JOIN maturity_levels ml ON ml.id = ro.maturity_level_id 
+                LEFT JOIN alliance_user_staff_groups ausg ON ausg.staff_group_id  = ro.mel_staff_group_id 
+                LEFT JOIN alliance_user_staff aus ON aus.carnet = ausg.carnet 
+                LEFT JOIN (SELECT 
+                                rt.result_id,
+                                t.name tag_name
+                            FROM result_tags rt 
+                                INNER JOIN tags t ON t.id = rt.tag_id 
+                            WHERE rt.is_active = TRUE
+                            GROUP BY rt.result_id
+                            ORDER BY rt.result_id ASC) rt ON rt.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                rq.result_id,
+                                GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') quantifications 
+                            FROM result_quantifications rq 
+                            WHERE rq.is_active = TRUE
+                                AND rq.quantification_role_id = 1
+                            GROUP BY rq.result_id) rq ON rq.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                rq.result_id,
+                                GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') extrapolated_estimates 
+                            FROM result_quantifications rq 
+                            WHERE rq.is_active = TRUE
+                                AND rq.quantification_role_id = 2
+                            GROUP BY rq.result_id) rq2 ON rq2.result_id = root.result_id
+                LEFT JOIN (SELECT
+                                ru.result_id,
+                                GROUP_CONCAT(CONCAT_WS('','• ',aus.first_name, ' ', aus.last_name, ' - Position: ', IFNULL(aus.\`position\`, 'N/D'), ' - Affiliation: ', IFNULL(aus.center, 'N/D')) SEPARATOR '\n') authors_contact_persons
+                            FROM result_users ru 
+                                INNER JOIN alliance_user_staff aus ON aus.carnet = ru.user_id 
+                            WHERE ru.user_role_id = 3
+                                AND ru.is_active = TRUE
+                            GROUP BY ru.result_id) acp ON acp.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                ria.result_id,
+                                GROUP_CONCAT('• ', cia.name, ' - Score: ', report_field(CONCAT('(', ias.id - 1 ,') ', ias.name), TRUE, TRUE), '\n', rgt.global_targets   SEPARATOR '\n') impact_area
+                            FROM result_impact_areas ria 
+                                LEFT JOIN clarisa_impact_areas cia ON cia.id = ria.impact_area_id 
+                                LEFT JOIN impact_area_scores ias ON ias.id = ria.impact_area_score_id 
+                                LEFT JOIN (SELECT
+                                                riagt.result_impact_area_id,
+                                                GROUP_CONCAT('\t◦ ', cgt.smo_code, ' - ', cgt.target SEPARATOR '\n') global_targets
+                                            FROM result_impact_area_global_target riagt
+                                                LEFT JOIN clarisa_global_targets cgt ON cgt.targetId = riagt.global_target_id 
+                                            WHERE riagt.is_active = TRUE
+                                            GROUP BY riagt.result_impact_area_id) rgt ON rgt.result_impact_area_id = ria.id 
+                            WHERE ria.is_active = TRUE
+                            GROUP BY ria.result_id) ria ON ria.result_id = root.result_id 
+            WHERE root.is_active = TRUE
+                AND root.is_snapshot = FALSE
+            ORDER BY root.result_id ASC; `);
+  }
+}

--- a/server/researchindicators/src/db/migrations/1780672573009-UpdateOicrLinkResult.ts
+++ b/server/researchindicators/src/db/migrations/1780672573009-UpdateOicrLinkResult.ts
@@ -1,0 +1,169 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateOicrLinkResult1780672573009 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE OR REPLACE VIEW report_oicr AS
+            SELECT
+                root.result_id,
+                report_field(ro.general_comment, TRUE, root.indicator_id = 5) general_comment,
+                report_field(ml.full_name , TRUE, root.indicator_id = 5) maturity_level,
+                report_field(ro.oicr_internal_code, TRUE, root.indicator_id = 5) oicr_internal_code,
+                report_field(ro.outcome_impact_statement, TRUE, root.indicator_id = 5) outcome_impact_statement,
+                report_field(ro.short_outcome_impact_statement, TRUE, root.indicator_id = 5) short_outcome_impact_statement,
+                report_field(ro.sharepoint_link, FALSE, root.indicator_id = 5) sharepoint_link,
+                report_field(CONCAT_WS('', aus.first_name, ' ', aus.last_name), TRUE, root.indicator_id = 5) mel_regional_expert,
+                report_field(rt.tag_name, TRUE , root.indicator_id = 5) tagging,
+                report_field(rq.quantifications, FALSE, root.indicator_id = 5) quantifications,
+                report_field(rq2.extrapolated_estimates , FALSE, root.indicator_id = 5) extrapolated_estimates,
+                report_field(acp.authors_contact_persons, FALSE, root.indicator_id = 5) authors_contact_persons,
+                report_field(IF(ro.for_external_use, 'YES', 'NO'), FALSE, root.indicator_id = 5) for_external_use,
+                report_field(ro.for_external_use_description, FALSE, root.indicator_id = 5) for_external_use_description,
+                report_field(ria.impact_area, TRUE, root.indicator_id = 5) impact_area,
+                report_field(treo.existing_oicr, TRUE, root.indicator_id = 5 AND rt.tag_id IN (2,3) AND rt.tag_id IS NOT NULL ) existing_oicr
+            FROM results root
+                LEFT JOIN result_oicrs ro ON ro.result_id = root.result_id 
+                LEFT JOIN maturity_levels ml ON ml.id = ro.maturity_level_id 
+                LEFT JOIN alliance_user_staff_groups ausg ON ausg.staff_group_id  = ro.mel_staff_group_id 
+                LEFT JOIN alliance_user_staff aus ON aus.carnet = ausg.carnet 
+                LEFT JOIN (SELECT 
+                                rt.result_id,
+                                rt.tag_id,
+                                t.name tag_name
+                            FROM result_tags rt 
+                                INNER JOIN tags t ON t.id = rt.tag_id 
+                            WHERE rt.is_active = TRUE
+                            GROUP BY rt.result_id
+                            ORDER BY rt.result_id ASC) rt ON rt.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                rq.result_id,
+                                GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') quantifications 
+                            FROM result_quantifications rq 
+                            WHERE rq.is_active = TRUE
+                                AND rq.quantification_role_id = 1
+                            GROUP BY rq.result_id) rq ON rq.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                rq.result_id,
+                                GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') extrapolated_estimates 
+                            FROM result_quantifications rq 
+                            WHERE rq.is_active = TRUE
+                                AND rq.quantification_role_id = 2
+                            GROUP BY rq.result_id) rq2 ON rq2.result_id = root.result_id
+                LEFT JOIN (SELECT
+                                ru.result_id,
+                                GROUP_CONCAT(CONCAT_WS('','• ',aus.first_name, ' ', aus.last_name, ' - Position: ', IFNULL(aus.\`position\`, 'N/D'), ' - Affiliation: ', IFNULL(aus.center, 'N/D')) SEPARATOR '\n') authors_contact_persons
+                            FROM result_users ru 
+                                INNER JOIN alliance_user_staff aus ON aus.carnet = ru.user_id 
+                            WHERE ru.user_role_id = 3
+                                AND ru.is_active = TRUE
+                            GROUP BY ru.result_id) acp ON acp.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                ria.result_id,
+                                GROUP_CONCAT('• ', cia.name, ' - Score: ', report_field(CONCAT('(', ias.id - 1 ,') ', ias.name), TRUE, TRUE), '\n', rgt.global_targets   SEPARATOR '\n') impact_area
+                            FROM result_impact_areas ria 
+                                LEFT JOIN clarisa_impact_areas cia ON cia.id = ria.impact_area_id 
+                                LEFT JOIN impact_area_scores ias ON ias.id = ria.impact_area_score_id 
+                                LEFT JOIN (SELECT
+                                                riagt.result_impact_area_id,
+                                                GROUP_CONCAT('\t◦ ', cgt.smo_code, ' - ', cgt.target SEPARATOR '\n') global_targets
+                                            FROM result_impact_area_global_target riagt
+                                                LEFT JOIN clarisa_global_targets cgt ON cgt.targetId = riagt.global_target_id 
+                                            WHERE riagt.is_active = TRUE
+                                            GROUP BY riagt.result_impact_area_id) rgt ON rgt.result_impact_area_id = ria.id 
+                            WHERE ria.is_active = TRUE
+                            GROUP BY ria.result_id) ria ON ria.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                treo.result_id ,
+                                CONCAT(teo.external_id, ' - ', teo.title, ' <',teo.handle_link,'>') existing_oicr
+                            FROM TEMP_result_external_oicrs treo 
+                                INNER JOIN TEMP_external_oicrs teo on teo.id = treo.external_oicr_id 
+                            WHERE treo.is_active = TRUE
+                            GROUP BY treo.result_id) treo ON treo.result_id = root.result_id 
+            WHERE root.is_active = TRUE
+                AND root.is_snapshot = FALSE
+            ORDER BY root.result_id ASC; `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE OR REPLACE VIEW report_oicr AS
+            SELECT
+                root.result_id,
+                report_field(ro.general_comment, TRUE, root.indicator_id = 5) general_comment,
+                report_field(ml.full_name , TRUE, root.indicator_id = 5) maturity_level,
+                report_field(ro.oicr_internal_code, TRUE, root.indicator_id = 5) oicr_internal_code,
+                report_field(ro.outcome_impact_statement, TRUE, root.indicator_id = 5) outcome_impact_statement,
+                report_field(ro.short_outcome_impact_statement, TRUE, root.indicator_id = 5) short_outcome_impact_statement,
+                report_field(ro.sharepoint_link, FALSE, root.indicator_id = 5) sharepoint_link,
+                report_field(CONCAT_WS('', aus.first_name, ' ', aus.last_name), TRUE, root.indicator_id = 5) mel_regional_expert,
+                report_field(rt.tag_name, TRUE , root.indicator_id = 5) tagging,
+                report_field(rq.quantifications, FALSE, root.indicator_id = 5) quantifications,
+                report_field(rq2.extrapolated_estimates , FALSE, root.indicator_id = 5) extrapolated_estimates,
+                report_field(acp.authors_contact_persons, FALSE, root.indicator_id = 5) authors_contact_persons,
+                report_field(IF(ro.for_external_use, 'YES', 'NO'), FALSE, root.indicator_id = 5) for_external_use,
+                report_field(ro.for_external_use_description, FALSE, root.indicator_id = 5) for_external_use_description,
+                report_field(ria.impact_area, TRUE, root.indicator_id = 5) impact_area,
+                report_field(treo.existing_oicr, TRUE, root.indicator_id = 5 AND rt.tag_id IN (2,3) AND rt.tag_id IS NOT NULL ) existing_oicr
+            FROM results root
+                LEFT JOIN result_oicrs ro ON ro.result_id = root.result_id 
+                LEFT JOIN maturity_levels ml ON ml.id = ro.maturity_level_id 
+                LEFT JOIN alliance_user_staff_groups ausg ON ausg.staff_group_id  = ro.mel_staff_group_id 
+                LEFT JOIN alliance_user_staff aus ON aus.carnet = ausg.carnet 
+                LEFT JOIN (SELECT 
+                                rt.result_id,
+                                rt.tag_id,
+                                t.name tag_name
+                            FROM result_tags rt 
+                                INNER JOIN tags t ON t.id = rt.tag_id 
+                            WHERE rt.is_active = TRUE
+                            GROUP BY rt.result_id
+                            ORDER BY rt.result_id ASC) rt ON rt.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                rq.result_id,
+                                GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') quantifications 
+                            FROM result_quantifications rq 
+                            WHERE rq.is_active = TRUE
+                                AND rq.quantification_role_id = 1
+                            GROUP BY rq.result_id) rq ON rq.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                rq.result_id,
+                                GROUP_CONCAT(CONCAT_WS('', '• Number: ',report_field(rq.quantification_number, TRUE, TRUE), ', Unit: ',report_field(rq.unit, TRUE, TRUE), ', Comment: ', report_field(rq.description, TRUE, TRUE)) SEPARATOR '\n') extrapolated_estimates 
+                            FROM result_quantifications rq 
+                            WHERE rq.is_active = TRUE
+                                AND rq.quantification_role_id = 2
+                            GROUP BY rq.result_id) rq2 ON rq2.result_id = root.result_id
+                LEFT JOIN (SELECT
+                                ru.result_id,
+                                GROUP_CONCAT(CONCAT_WS('','• ',aus.first_name, ' ', aus.last_name, ' - Position: ', IFNULL(aus.\`position\`, 'N/D'), ' - Affiliation: ', IFNULL(aus.center, 'N/D')) SEPARATOR '\n') authors_contact_persons
+                            FROM result_users ru 
+                                INNER JOIN alliance_user_staff aus ON aus.carnet = ru.user_id 
+                            WHERE ru.user_role_id = 3
+                                AND ru.is_active = TRUE
+                            GROUP BY ru.result_id) acp ON acp.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                ria.result_id,
+                                GROUP_CONCAT('• ', cia.name, ' - Score: ', report_field(CONCAT('(', ias.id - 1 ,') ', ias.name), TRUE, TRUE), '\n', rgt.global_targets   SEPARATOR '\n') impact_area
+                            FROM result_impact_areas ria 
+                                LEFT JOIN clarisa_impact_areas cia ON cia.id = ria.impact_area_id 
+                                LEFT JOIN impact_area_scores ias ON ias.id = ria.impact_area_score_id 
+                                LEFT JOIN (SELECT
+                                                riagt.result_impact_area_id,
+                                                GROUP_CONCAT('\t◦ ', cgt.smo_code, ' - ', cgt.target SEPARATOR '\n') global_targets
+                                            FROM result_impact_area_global_target riagt
+                                                LEFT JOIN clarisa_global_targets cgt ON cgt.targetId = riagt.global_target_id 
+                                            WHERE riagt.is_active = TRUE
+                                            GROUP BY riagt.result_impact_area_id) rgt ON rgt.result_impact_area_id = ria.id 
+                            WHERE ria.is_active = TRUE
+                            GROUP BY ria.result_id) ria ON ria.result_id = root.result_id 
+                LEFT JOIN (SELECT 
+                                treo.result_id ,
+                                CONCAT(teo.external_id, ' - ', teo.title) existing_oicr
+                            FROM TEMP_result_external_oicrs treo 
+                                INNER JOIN TEMP_external_oicrs teo on teo.id = treo.external_oicr_id 
+                            WHERE treo.is_active = TRUE
+                            GROUP BY treo.result_id) treo ON treo.result_id = root.result_id 
+            WHERE root.is_active = TRUE
+                AND root.is_snapshot = FALSE
+            ORDER BY root.result_id ASC; `);
+    }
+
+}

--- a/server/researchindicators/src/domain/entities/link-results/link-results.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/link-results/link-results.controller.spec.ts
@@ -7,6 +7,7 @@ import { ResponseUtils } from '../../shared/utils/response.utils';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
 import { LinkResultRolesEnum } from '../link-result-roles/enum/link-result-roles.enum';
 import { IndicatorsEnum } from '../indicators/enum/indicators.enum';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 jest.mock('../../shared/utils/response.utils');
 
@@ -34,7 +35,10 @@ describe('LinkResultsController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(ResultStatusGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
     controller = module.get(LinkResultsController);
   });
 

--- a/server/researchindicators/src/domain/entities/link-results/link-results.controller.ts
+++ b/server/researchindicators/src/domain/entities/link-results/link-results.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpStatus,
   Patch,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { LinkResultsService } from './link-results.service';
@@ -16,6 +17,7 @@ import { ServiceResponseDto } from '../../shared/global-dto/service-response.dto
 import { GetResultVersion } from '../../shared/decorators/versioning.decorator';
 import { RESULT_CODE, ResultsUtil } from '../../shared/utils/results.util';
 import { IndicatorsEnum } from '../indicators/enum/indicators.enum';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 @ApiTags('Results')
 @ApiBearerAuth()
@@ -49,6 +51,7 @@ export class LinkResultsController {
   }
 
   @Patch(`details/${RESULT_CODE}`)
+  @UseGuards(ResultStatusGuard)
   @ApiBody({ type: CreateLinkResultDto })
   @GetResultVersion()
   async patchLinkResultsDetails(@Body() body: CreateLinkResultDto) {

--- a/server/researchindicators/src/domain/entities/reports/handlers/star-results-metadata/star-results-metadata.columns.ts
+++ b/server/researchindicators/src/domain/entities/reports/handlers/star-results-metadata/star-results-metadata.columns.ts
@@ -207,7 +207,7 @@ export const STAR_RESULTS_METADATA_RAW_COLUMNS: ExcelColumnSpec[] = [
   },
   { key: 'oicr_internal_code', header: 'OICR No', width: 20 },
   { key: 'tagging', header: 'Tagging', width: 28 },
-  { key: 'general_comment', header: 'Existing OICR', width: 36 },
+  { key: 'existing_oicr', header: 'Existing OICR', width: 36 },
   { key: 'maturity_level', header: 'Maturity of change', width: 28 },
   {
     key: 'outcome_impact_statement',

--- a/server/researchindicators/src/domain/entities/reports/repositories/star-results-export.repository.ts
+++ b/server/researchindicators/src/domain/entities/reports/repositories/star-results-export.repository.ts
@@ -136,7 +136,8 @@ export class StarResultsExportRepository {
         CONCAT_WS(CHAR(10), oc.quantifications, oc.extrapolated_estimates) AS quantification,
         oc.authors_contact_persons AS authors_contact_persons,
         oc.for_external_use AS for_external_use,
-        oc.for_external_use_description AS for_external_use_description
+        oc.for_external_use_description AS for_external_use_description,
+        oc.existing_oicr AS existing_oicr
       FROM report_general_information gi
       LEFT JOIN report_alliance_alignment aa ON aa.result_id = gi.result_id
       LEFT JOIN report_partners pr ON pr.result_id = gi.result_id

--- a/server/researchindicators/src/domain/entities/result-cap-sharing-ip/result-cap-sharing-ip.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-cap-sharing-ip/result-cap-sharing-ip.controller.spec.ts
@@ -5,6 +5,7 @@ import { ResultIpRightsService } from '../result-ip-rights/result-ip-rights.serv
 import { ResultsUtil } from '../../shared/utils/results.util';
 import { ResponseUtils } from '../../shared/utils/response.utils';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 jest.mock('../../shared/utils/response.utils');
 
@@ -32,7 +33,10 @@ describe('ResultCapSharingIpController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(ResultStatusGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
     controller = module.get(ResultCapSharingIpController);
   });
 

--- a/server/researchindicators/src/domain/entities/result-cap-sharing-ip/result-cap-sharing-ip.controller.ts
+++ b/server/researchindicators/src/domain/entities/result-cap-sharing-ip/result-cap-sharing-ip.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpStatus,
   Patch,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ResponseUtils } from '../../shared/utils/response.utils';
@@ -13,6 +14,7 @@ import { RESULT_CODE, ResultsUtil } from '../../shared/utils/results.util';
 import { GetResultVersion } from '../../shared/decorators/versioning.decorator';
 import { ResultIpRightsService } from '../result-ip-rights/result-ip-rights.service';
 import { UpdateIpRightDto } from '../result-ip-rights/dto/update-ip-right.dto';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 @ApiTags('Result Capacity Sharing')
 @UseInterceptors(SetUpInterceptor)
@@ -43,6 +45,7 @@ export class ResultCapSharingIpController {
 
   @Patch(RESULT_CODE)
   @GetResultVersion()
+  @UseGuards(ResultStatusGuard)
   @ApiOperation({
     deprecated: true,
   })

--- a/server/researchindicators/src/domain/entities/result-evidences/dto/create-result-evidence.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-evidences/dto/create-result-evidence.dto.ts
@@ -11,6 +11,13 @@ export class CreateResultEvidenceDto {
   })
   evidence: ResultEvidence[];
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'CGSpace link',
+  })
+  cgspace_link?: string;
+
   @ApiProperty({ type: [ResultNotableReference] })
   notable_references?: ResultNotableReference[];
 }

--- a/server/researchindicators/src/domain/entities/result-evidences/result-evidences.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-evidences/result-evidences.service.spec.ts
@@ -9,11 +9,14 @@ import { ResultsUtil } from '../../shared/utils/results.util';
 import { IndicatorsEnum } from '../indicators/enum/indicators.enum';
 import { EvidenceRoleEnum } from '../evidence-roles/enums/evidence-role.enum';
 import { CreateResultEvidenceDto } from './dto/create-result-evidence.dto';
+import { ResultOicr } from '../result-oicr/entities/result-oicr.entity';
 
 describe('ResultEvidencesService', () => {
   let service: ResultEvidencesService;
   const find = jest.fn();
   const transaction = jest.fn();
+  const oicrUpdate = jest.fn().mockResolvedValue(undefined);
+  const oicrFindOne = jest.fn();
 
   const mockRepository = {
     find,
@@ -22,8 +25,15 @@ describe('ResultEvidencesService', () => {
     },
   };
 
+  const mockOicrRepository = {
+    update: oicrUpdate,
+    findOne: oicrFindOne,
+  };
+
   const mockDataSource = {
-    getRepository: jest.fn().mockReturnValue(mockRepository),
+    getRepository: jest.fn((entity) =>
+      entity === ResultOicr ? mockOicrRepository : mockRepository,
+    ),
     transaction,
   };
 
@@ -108,7 +118,7 @@ describe('ResultEvidencesService', () => {
       createSpy.mockRestore();
     });
 
-    it('should upsert notable references for OICR indicator', async () => {
+    it('should upsert notable references and persist cgspace_link for OICR indicator', async () => {
       resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
       jest.spyOn(service, 'create').mockResolvedValue([] as any);
       transaction.mockImplementation(
@@ -120,6 +130,7 @@ describe('ResultEvidencesService', () => {
         notable_references: [
           { link: 'l', notable_reference_type_id: 1 } as any,
         ],
+        cgspace_link: 'https://cgspace.cgiar.org/handle/10568/12345',
       };
 
       await service.updateResultEvidences(2, body);
@@ -129,7 +140,24 @@ describe('ResultEvidencesService', () => {
         body.notable_references,
         ['notable_reference_type_id', 'link'],
       );
+      expect(oicrUpdate).toHaveBeenCalledWith(2, {
+        cgspace_link: body.cgspace_link,
+      });
       resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
+    });
+
+    it('should not update cgspace_link when indicator is not OICR', async () => {
+      jest.spyOn(service, 'create').mockResolvedValue([] as any);
+      transaction.mockImplementation(
+        async (cb: (m: unknown) => Promise<unknown>) => cb({}),
+      );
+
+      await service.updateResultEvidences(3, {
+        evidence: [{ evidence_url: 'u' } as any],
+        cgspace_link: 'https://cgspace.cgiar.org/handle/10568/99999',
+      });
+
+      expect(oicrUpdate).not.toHaveBeenCalled();
     });
   });
 
@@ -147,18 +175,32 @@ describe('ResultEvidencesService', () => {
           is_active: true,
         },
       });
-      expect(out).toEqual({ evidence: ev, notable_references: null });
+      expect(out).toEqual({
+        evidence: ev,
+        notable_references: null,
+        cgspace_link: null,
+      });
     });
 
-    it('should include notable references for OICR', async () => {
+    it('should include notable references and cgspace_link for OICR', async () => {
       resultsUtilStub.indicatorId = IndicatorsEnum.OICR;
       find.mockResolvedValue([]);
       mockNotableRefs.find.mockResolvedValue([{ ref: 1 }]);
+      const cgspaceLink = 'https://cgspace.cgiar.org/handle/10568/54321';
+      oicrFindOne.mockResolvedValue({ cgspace_link: cgspaceLink });
 
       const out = await service.findPrincipalEvidence(6);
 
       expect(mockNotableRefs.find).toHaveBeenCalledWith(6);
-      expect(out.notable_references).toEqual([{ ref: 1 }]);
+      expect(oicrFindOne).toHaveBeenCalledWith({
+        select: { cgspace_link: true },
+        where: { result_id: 6, is_active: true },
+      });
+      expect(out).toEqual({
+        evidence: [],
+        notable_references: [{ ref: 1 }],
+        cgspace_link: cgspaceLink,
+      });
       resultsUtilStub.indicatorId = IndicatorsEnum.KNOWLEDGE_PRODUCT;
     });
   });

--- a/server/researchindicators/src/domain/entities/result-evidences/result-evidences.service.ts
+++ b/server/researchindicators/src/domain/entities/result-evidences/result-evidences.service.ts
@@ -10,6 +10,7 @@ import { UpdateDataUtil } from '../../shared/utils/update-data.util';
 import { ResultNotableReferencesService } from '../result-notable-references/result-notable-references.service';
 import { ResultsUtil } from '../../shared/utils/results.util';
 import { IndicatorsEnum } from '../indicators/enum/indicators.enum';
+import { ResultOicr } from '../result-oicr/entities/result-oicr.entity';
 @Injectable()
 export class ResultEvidencesService extends BaseServiceSimple<
   ResultEvidence,
@@ -53,6 +54,10 @@ export class ResultEvidencesService extends BaseServiceSimple<
           filterNotableReferences ?? [],
           ['notable_reference_type_id', 'link'],
         );
+
+        await this.dataSource
+          .getRepository(ResultOicr)
+          .update(resultId, { cgspace_link: resultEvidences?.cgspace_link });
       }
 
       return await this.create(
@@ -83,9 +88,21 @@ export class ResultEvidencesService extends BaseServiceSimple<
     const returnEvidences = {
       evidence: resultEvidences,
       notable_references: null,
+      cgspace_link: null,
     };
 
     if (this._resultsUtil.indicatorId == IndicatorsEnum.OICR) {
+      const oicr = await this.dataSource.getRepository(ResultOicr).findOne({
+        select: {
+          cgspace_link: true,
+        },
+        where: {
+          result_id: resultId,
+          is_active: true,
+        },
+      });
+      returnEvidences.cgspace_link = oicr?.cgspace_link;
+
       const notableReferences =
         await this.resultNotableReferencesService.find(resultId);
       returnEvidences.notable_references = notableReferences;

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.controller.spec.ts
@@ -5,6 +5,7 @@ import { ResultInnovationDevService } from './result-innovation-dev.service';
 import { ResultsUtil } from '../../shared/utils/results.util';
 import { ResponseUtils } from '../../shared/utils/response.utils';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 jest.mock('../../shared/utils/response.utils');
 
@@ -32,7 +33,10 @@ describe('ResultInnovationDevController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(ResultStatusGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
     controller = module.get(ResultInnovationDevController);
   });
 

--- a/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.controller.ts
+++ b/server/researchindicators/src/domain/entities/result-innovation-dev/result-innovation-dev.controller.ts
@@ -5,6 +5,7 @@ import {
   Patch,
   UseInterceptors,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { ResultInnovationDevService } from './result-innovation-dev.service';
 import { CreateResultInnovationDevDto } from './dto/create-result-innovation-dev.dto';
@@ -13,6 +14,7 @@ import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
 import { RESULT_CODE, ResultsUtil } from '../../shared/utils/results.util';
 import { ResponseUtils } from '../../shared/utils/response.utils';
 import { GetResultVersion } from '../../shared/decorators/versioning.decorator';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 @ApiTags('Results Innovation Development')
 @ApiBearerAuth()
@@ -26,6 +28,7 @@ export class ResultInnovationDevController {
 
   @Patch(`${RESULT_CODE}`)
   @GetResultVersion()
+  @UseGuards(ResultStatusGuard)
   create(@Body() createResultInnovationDevDto: CreateResultInnovationDevDto) {
     return this.resultInnovationDevService
       .update(this._currentResult.resultId, createResultInnovationDevDto)

--- a/server/researchindicators/src/domain/entities/result-ip-rights/result-ip-rights.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-ip-rights/result-ip-rights.controller.spec.ts
@@ -5,6 +5,7 @@ import { ResultIpRightsService } from './result-ip-rights.service';
 import { ResultsUtil } from '../../shared/utils/results.util';
 import { ResponseUtils } from '../../shared/utils/response.utils';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 jest.mock('../../shared/utils/response.utils');
 
@@ -32,7 +33,10 @@ describe('ResultIpRightsController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(ResultStatusGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
     controller = module.get(ResultIpRightsController);
   });
 

--- a/server/researchindicators/src/domain/entities/result-ip-rights/result-ip-rights.controller.ts
+++ b/server/researchindicators/src/domain/entities/result-ip-rights/result-ip-rights.controller.ts
@@ -5,6 +5,7 @@ import {
   Patch,
   HttpStatus,
   UseInterceptors,
+  UseGuards,
 } from '@nestjs/common';
 import { ResultIpRightsService } from './result-ip-rights.service';
 import { UpdateIpRightDto } from './dto/update-ip-right.dto';
@@ -13,6 +14,7 @@ import { GetResultVersion } from '../../shared/decorators/versioning.decorator';
 import { ResponseUtils } from '../../shared/utils/response.utils';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { SetUpInterceptor } from '../../shared/Interceptors/setup.interceptor';
+import { ResultStatusGuard } from '../../shared/guards/result-status.guard';
 
 @ApiTags('Intellectual Property Rights')
 @UseInterceptors(SetUpInterceptor)
@@ -41,6 +43,7 @@ export class ResultIpRightsController {
 
   @Patch(RESULT_CODE)
   @GetResultVersion()
+  @UseGuards(ResultStatusGuard)
   update(@Body() updateData: UpdateIpRightDto) {
     return this._resultIpRightsService
       .update(this._resultsUtil.resultId, updateData)

--- a/server/researchindicators/src/domain/entities/result-oicr/dto/create-result-oicr.dto.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/dto/create-result-oicr.dto.ts
@@ -29,4 +29,6 @@ export class CreateResultOicrDto {
   base_information: CreateResultDto;
   @ApiProperty({ type: ExtraInfoDto, required: false })
   extra_info?: ExtraInfoDto;
+  @ApiProperty({ type: String, required: false })
+  cgspace_link?: string;
 }

--- a/server/researchindicators/src/domain/entities/result-oicr/entities/result-oicr.entity.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/entities/result-oicr.entity.ts
@@ -15,6 +15,13 @@ export class ResultOicr extends AuditableEntity {
 
   @Column({
     type: 'text',
+    name: 'cgspace_link',
+    nullable: true,
+  })
+  cgspace_link: string;
+
+  @Column({
+    type: 'text',
     name: 'oicr_internal_code',
     comment: 'OICR internal code for the result',
     nullable: true,

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.spec.ts
@@ -613,8 +613,10 @@ describe('ResultOicrService', () => {
         title: 'Test',
         description: 'Test Description',
       });
+      const cgspaceLink = 'https://cgspace.cgiar.org/handle/10568/12345';
       mockResultOicrRepository.findOne.mockResolvedValue({
         general_comment: 'Test comment',
+        cgspace_link: cgspaceLink,
       } as any);
 
       // Act
@@ -625,8 +627,14 @@ describe('ResultOicrService', () => {
       expect((service as any).findStepTwoOicr).toHaveBeenCalledWith(resultId);
       expect(mockResultsService.findGeoLocation).toHaveBeenCalledWith(resultId);
       expect(mockResultsService.findBaseInfo).toHaveBeenCalledWith(resultId);
+      expect(mockResultOicrRepository.findOne).toHaveBeenCalledWith({
+        where: { result_id: resultId },
+        select: { general_comment: true, cgspace_link: true },
+      });
       expect(result.step_one).toEqual(stepOneResult);
       expect(result.step_two).toEqual(stepTwoResult);
+      expect(result.cgspace_link).toBe(cgspaceLink);
+      expect(result.step_four).toEqual({ general_comment: 'Test comment' });
     });
 
     it('should handle errors when finding modal data', async () => {

--- a/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
+++ b/server/researchindicators/src/domain/entities/result-oicr/result-oicr.service.ts
@@ -490,16 +490,20 @@ export class ResultOicrService {
     const stepTwo = await this.findStepTwoOicr(resultId);
     const stepThree = await this.resultService.findGeoLocation(resultId);
     const baseInformation = await this.resultService.findBaseInfo(resultId);
-    const stepFour = await this.mainRepo
+    const { general_comment: stepFour, cgspace_link } = await this.mainRepo
       .findOne({
         where: {
           result_id: resultId,
         },
         select: {
           general_comment: true,
+          cgspace_link: true,
         },
       })
-      .then((result) => result?.general_comment || '');
+      .then((result) => ({
+        general_comment: result?.general_comment,
+        cgspace_link: result?.cgspace_link,
+      }));
 
     return {
       step_one: stepOne,
@@ -509,6 +513,7 @@ export class ResultOicrService {
         general_comment: stepFour,
       },
       base_information: baseInformation,
+      cgspace_link,
     };
   }
 

--- a/server/researchindicators/src/domain/entities/result-status-workflow/entities/result-status-workflow.entity.ts
+++ b/server/researchindicators/src/domain/entities/result-status-workflow/entities/result-status-workflow.entity.ts
@@ -49,6 +49,14 @@ export class ResultStatusWorkflow extends AuditableEntity {
 
   @Column({
     type: 'boolean',
+    name: 'is_status_change_validation_required',
+    nullable: false,
+    default: false,
+  })
+  is_status_change_validation_required!: boolean;
+
+  @Column({
+    type: 'boolean',
     name: 'is_editable_date',
     nullable: false,
     default: false,

--- a/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.controller.spec.ts
@@ -67,7 +67,12 @@ describe('ResultStatusWorkflowController', () => {
   });
 
   it('getConfigWorkflow', async () => {
-    const cfg = {};
+    const cfg = [
+      {
+        result_status_id: 3,
+        is_status_change_validation_required: true,
+      },
+    ];
     mockService.getConfigWorkflowByIndicatorAndFromStatus.mockResolvedValue(
       cfg,
     );
@@ -76,6 +81,11 @@ describe('ResultStatusWorkflowController', () => {
     expect(
       mockService.getConfigWorkflowByIndicatorAndFromStatus,
     ).toHaveBeenCalledWith(1, 2);
+    expect(ResponseUtils.format).toHaveBeenCalledWith({
+      data: cfg,
+      description: 'Config workflow found',
+      status: HttpStatus.OK,
+    });
   });
 
   it('getNextSteps', async () => {

--- a/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.spec.ts
@@ -145,7 +145,13 @@ describe('ResultStatusWorkflowService', () => {
 
     it('should return enriched statuses with transition_direction when showOnlyWorkflow is false', async () => {
       mockWorkflowFind
-        .mockResolvedValueOnce([{ to_status_id: 2, is_active: true }])
+        .mockResolvedValueOnce([
+          {
+            to_status_id: 2,
+            is_active: true,
+            is_status_change_validation_required: true,
+          },
+        ])
         .mockResolvedValueOnce([]);
       mockStatusFind.mockResolvedValue([
         { result_status_id: 2, is_active: true },
@@ -156,7 +162,13 @@ describe('ResultStatusWorkflowService', () => {
         1,
       );
 
-      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([
+        expect.objectContaining({
+          result_status_id: 2,
+          transition_direction: expect.any(String),
+          is_status_change_validation_required: true,
+        }),
+      ]);
     });
 
     it('should return empty array when no to-statuses are found', async () => {
@@ -171,6 +183,90 @@ describe('ResultStatusWorkflowService', () => {
       );
 
       expect(result).toEqual([]);
+    });
+
+    it('should default is_status_change_validation_required to false when absent on workflow', async () => {
+      mockWorkflowFind
+        .mockResolvedValueOnce([{ to_status_id: 2, is_active: true }])
+        .mockResolvedValueOnce([]);
+      mockStatusFind.mockResolvedValue([
+        { result_status_id: 2, is_active: true, name: 'Review' },
+      ]);
+
+      const result = await service.getConfigWorkflowByIndicatorAndFromStatus(
+        1,
+        1,
+      );
+
+      expect(result[0].is_status_change_validation_required).toBe(false);
+    });
+
+    it('should map is_status_change_validation_required per destination status', async () => {
+      mockWorkflowFind
+        .mockResolvedValueOnce([
+          {
+            to_status_id: 2,
+            is_status_change_validation_required: true,
+          },
+          {
+            to_status_id: 3,
+            is_status_change_validation_required: false,
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockStatusFind.mockResolvedValue([
+        { result_status_id: 2, is_active: true },
+        { result_status_id: 3, is_active: true },
+      ]);
+
+      const result = await service.getConfigWorkflowByIndicatorAndFromStatus(
+        1,
+        1,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        result_status_id: 2,
+        is_status_change_validation_required: true,
+      });
+      expect(result[1]).toMatchObject({
+        result_status_id: 3,
+        is_status_change_validation_required: false,
+      });
+    });
+
+    it('should include is_status_change_validation_required on raw workflow when showOnlyWorkflow is true', async () => {
+      const mockStatuses = [
+        {
+          to_status_id: 2,
+          indicator_id: 1,
+          from_status_id: 1,
+          is_status_change_validation_required: true,
+        },
+      ];
+      mockWorkflowFind.mockResolvedValue(mockStatuses);
+
+      const result = await service.getConfigWorkflowByIndicatorAndFromStatus(
+        1,
+        1,
+        true,
+      );
+
+      expect(result[0].is_status_change_validation_required).toBe(true);
+    });
+
+    it('should query workflows by indicator and from status', async () => {
+      mockWorkflowFind.mockResolvedValue([]);
+
+      await service.getConfigWorkflowByIndicatorAndFromStatus(5, 10);
+
+      expect(mockWorkflowFind).toHaveBeenCalledWith({
+        where: {
+          indicator_id: 5,
+          is_active: true,
+          from_status_id: 10,
+        },
+      });
     });
   });
 
@@ -194,6 +290,33 @@ describe('ResultStatusWorkflowService', () => {
         expect.objectContaining({ where: { result_id: 10, is_active: true } }),
       );
       expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should propagate is_status_change_validation_required for next steps', async () => {
+      mockResultFindOne.mockResolvedValue({
+        indicator_id: 1,
+        result_status_id: 2,
+      });
+      mockWorkflowFind
+        .mockResolvedValueOnce([
+          {
+            to_status_id: 3,
+            is_status_change_validation_required: true,
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockStatusFind.mockResolvedValue([
+        { result_status_id: 3, is_active: true },
+      ]);
+
+      const result = await service.getNextStepsByResultId(10);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          result_status_id: 3,
+          is_status_change_validation_required: true,
+        }),
+      ]);
     });
   });
 

--- a/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.ts
+++ b/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.ts
@@ -48,7 +48,7 @@ export class ResultStatusWorkflowService {
     private readonly currentResult: ResultsUtil,
     private readonly currentUserUtil: CurrentUserUtil,
     private readonly handlerService: StatusWorkflowFunctionHandlerService,
-  ) {}
+  ) { }
 
   private async getStatusesByIds(statusIds: number[]) {
     return this.dataSource.getRepository(ResultStatus).find({

--- a/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.ts
+++ b/server/researchindicators/src/domain/entities/result-status-workflow/result-status-workflow.service.ts
@@ -156,6 +156,9 @@ export class ResultStatusWorkflowService {
     if (showOnlyWorkflow) return statuses;
 
     const toStatusIds = statuses.map((el) => el.to_status_id);
+    const workflowByToStatusId = new Map(
+      statuses.map((w) => [w.to_status_id, w]),
+    );
     const [toStatuses, depthMap] = await Promise.all([
       this.getStatusesByIds(toStatusIds),
       this.getStatusDepthMapByIndicatorId(indicatorId),
@@ -175,6 +178,9 @@ export class ResultStatusWorkflowService {
           s.result_status_id,
           depthMap,
         ),
+        is_status_change_validation_required:
+          workflowByToStatusId.get(s.result_status_id)
+            ?.is_status_change_validation_required ?? false,
       }));
   }
 

--- a/server/researchindicators/src/domain/entities/results/repositories/result.repository.spec.ts
+++ b/server/researchindicators/src/domain/entities/results/repositories/result.repository.spec.ts
@@ -5,6 +5,10 @@ import { CurrentUserUtil } from '../../../shared/utils/current-user.util';
 import { FindAllOptions } from '../../../shared/enum/find-all-options';
 import { AllianceUserStaff } from '../../alliance-user-staff/entities/alliance-user-staff.entity';
 import { SecUser } from '../../../complementary-entities/secondary/user/dto/sec-user.dto';
+import { ResultSortEnum } from '../enum/result-sort.enum';
+import { ResultStatusEnum } from '../../result-status/enum/result-status.enum';
+import { ReportingPlatformEnum } from '../enum/reporting-platform.enum';
+import { IndicatorsEnum } from '../../indicators/enum/indicators.enum';
 
 describe('ResultRepository', () => {
   let repository: ResultRepository;
@@ -360,6 +364,222 @@ describe('ResultRepository', () => {
         'UPDATE sec_users SET carnet = ? WHERE sec_user_id = ?',
         ['NEW', 4],
       );
+    });
+  });
+
+  const emptyFindResultsV2Filters = () => ({
+    status: [] as ResultStatusEnum[],
+    contracts: [] as string[],
+    years: [] as string[],
+    sources: [] as ReportingPlatformEnum[],
+    indicators: [] as IndicatorsEnum[],
+    currentUser: { onlyOwnResults: false, userId: 42 },
+  });
+
+  describe('findResultsV2 public link SQL helpers', () => {
+    it('buildFindResultsV2BuiltPublicLinkSqlExpression returns NULL until built URLs are defined', () => {
+      expect(
+        repository['buildFindResultsV2BuiltPublicLinkSqlExpression'](),
+      ).toBe('NULL');
+    });
+
+    it('buildFindResultsV2PublicLinkSqlExpression uses PRMS/TIP column and built branch', () => {
+      const expr = repository['buildFindResultsV2PublicLinkSqlExpression']();
+      expect(expr).toContain("r.platform_code IN ('PRMS', 'TIP')");
+      expect(expr).toContain('r.public_link');
+      expect(expr).toContain('NULL');
+    });
+
+    it('buildFindResultsV2SearchStaticWhereFragment matches on effective public_link and cgspace_link', () => {
+      const where = repository['buildFindResultsV2SearchStaticWhereFragment']();
+      expect(where).toContain('ro.cgspace_link LIKE CONCAT');
+      expect(where).toMatch(
+        /\(IF\([\s\S]*r\.public_link[\s\S]*NULL[\s\S]*\)\) LIKE CONCAT/,
+      );
+    });
+
+    it('buildFindResultsV2SearchRelevanceSelectFragment scores effective public_link and cgspace_link', () => {
+      const relevance = repository[
+        'buildFindResultsV2SearchRelevanceSelectFragment'
+      ](['anna']);
+      expect(relevance).toContain('ro.cgspace_link LIKE CONCAT');
+      expect(relevance).toMatch(
+        /CASE WHEN \(IF\([\s\S]*r\.public_link[\s\S]*\) LIKE CONCAT\('%', \?, '%'\) THEN 500/,
+      );
+      expect(relevance).toContain('_search_relevance');
+    });
+
+    it('splitFindResultsV2CreatorNameTokens splits on whitespace', () => {
+      expect(
+        repository['splitFindResultsV2CreatorNameTokens']('  david   casanas '),
+      ).toEqual(['david', 'casanas']);
+    });
+
+    it('splitFindResultsV2CreatorNameTokens falls back to full search when empty after trim', () => {
+      expect(repository['splitFindResultsV2CreatorNameTokens']('   ')).toEqual([
+        '   ',
+      ]);
+    });
+  });
+
+  describe('findResultsV2', () => {
+    it('joins result_oicrs and selects cgspace_link', async () => {
+      querySpy
+        .mockResolvedValueOnce([{ total: 0 }])
+        .mockResolvedValueOnce([]);
+      await repository.findResultsV2('', undefined, undefined, emptyFindResultsV2Filters());
+      const mainSql = querySpy.mock.calls[1][0] as string;
+      expect(mainSql).toContain('LEFT JOIN result_oicrs ro ON ro.result_id = r.result_id');
+      expect(mainSql).toContain('ro.cgspace_link');
+      expect(mainSql).toMatch(/IF\([\s\S]*AS public_link/);
+    });
+
+    it('omits search fragments when search is empty', async () => {
+      querySpy
+        .mockResolvedValueOnce([{ total: 0 }])
+        .mockResolvedValueOnce([]);
+      await repository.findResultsV2('', undefined, undefined, emptyFindResultsV2Filters());
+      const countSql = querySpy.mock.calls[0][0] as string;
+      const mainSql = querySpy.mock.calls[1][0] as string;
+      expect(countSql).not.toContain('ro.cgspace_link LIKE');
+      expect(mainSql).not.toContain('_search_relevance');
+      expect(querySpy.mock.calls[0][1]).toEqual([]);
+      expect(querySpy.mock.calls[1][1]).toEqual([100, 0]);
+    });
+
+    it('includes public_link and cgspace_link search with aligned placeholder counts', async () => {
+      const search = '10568/12345';
+      const staticWhereCount =
+        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT'];
+      const staticRelevanceCount =
+        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT'];
+      querySpy
+        .mockResolvedValueOnce([{ total: 1 }])
+        .mockResolvedValueOnce([{ result_id: 1, _search_relevance: 500 }]);
+      await repository.findResultsV2(
+        search,
+        { page: 1, limit: 10 },
+        undefined,
+        emptyFindResultsV2Filters(),
+      );
+      const countParams = querySpy.mock.calls[0][1] as unknown[];
+      const mainParams = querySpy.mock.calls[1][1] as unknown[];
+      const countSql = querySpy.mock.calls[0][0] as string;
+      const mainSql = querySpy.mock.calls[1][0] as string;
+
+      expect(countSql).toContain('ro.cgspace_link LIKE CONCAT');
+      expect(mainSql).toContain('ORDER BY _search_relevance DESC');
+      expect(countParams).toHaveLength(staticWhereCount + 2);
+      expect(countParams.every((p) => p === search)).toBe(true);
+      expect(mainParams).toHaveLength(
+        staticRelevanceCount + staticWhereCount + 4 + 2,
+      );
+      expect(mainParams.slice(0, staticRelevanceCount).every((p) => p === search)).toBe(
+        true,
+      );
+      expect(
+        mainParams
+          .slice(staticRelevanceCount, staticRelevanceCount + staticWhereCount)
+          .every((p) => p === search),
+      ).toBe(true);
+      expect(mainParams.slice(-2)).toEqual([10, 0]);
+    });
+
+    it('binds creator-name tokens separately for multi-word search', async () => {
+      const staticWhereCount =
+        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT'];
+      const staticRelevanceCount =
+        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT'];
+      querySpy
+        .mockResolvedValueOnce([{ total: 0 }])
+        .mockResolvedValueOnce([]);
+      await repository.findResultsV2(
+        'john doe',
+        undefined,
+        undefined,
+        emptyFindResultsV2Filters(),
+      );
+      const countParams = querySpy.mock.calls[0][1] as unknown[];
+      const mainParams = querySpy.mock.calls[1][1] as unknown[];
+      const countSql = querySpy.mock.calls[0][0] as string;
+      const creatorWhereOffset = staticWhereCount;
+
+      expect(countSql).toContain('su.first_name LIKE');
+      expect(countParams).toHaveLength(staticWhereCount + 4);
+      expect(countParams.slice(0, staticWhereCount).every((p) => p === 'john doe')).toBe(
+        true,
+      );
+      expect(countParams.slice(creatorWhereOffset)).toEqual([
+        'john',
+        'john',
+        'doe',
+        'doe',
+      ]);
+      expect(mainParams.slice(11, 15)).toEqual(['john', 'john', 'doe', 'doe']);
+      expect(mainParams.slice(25, 29)).toEqual(['john', 'john', 'doe', 'doe']);
+    });
+
+    it('strips _search_relevance from returned rows when search is provided', async () => {
+      querySpy
+        .mockResolvedValueOnce([{ total: 1 }])
+        .mockResolvedValueOnce([
+          { result_id: 9, title: 'T', _search_relevance: 2000 },
+        ]);
+      const out = await repository.findResultsV2(
+        'STAR-1',
+        undefined,
+        undefined,
+        emptyFindResultsV2Filters(),
+      );
+      expect(out.data[0]).toEqual({ result_id: 9, title: 'T' });
+      expect(out.data[0]).not.toHaveProperty('_search_relevance');
+    });
+
+    it('applies onlyOwnResults filter in SQL', async () => {
+      querySpy
+        .mockResolvedValueOnce([{ total: 0 }])
+        .mockResolvedValueOnce([]);
+      const filters = emptyFindResultsV2Filters();
+      filters.currentUser.onlyOwnResults = true;
+      await repository.findResultsV2('', undefined, undefined, filters);
+      const mainSql = querySpy.mock.calls[1][0] as string;
+      expect(mainSql).toContain('AND r.created_by = 42');
+    });
+
+    it('uses custom sort when search is absent', async () => {
+      querySpy
+        .mockResolvedValueOnce([{ total: 0 }])
+        .mockResolvedValueOnce([]);
+      await repository.findResultsV2(
+        '',
+        { page: 2, limit: 5 },
+        { field: ResultSortEnum.RESULT_TITLE, order: 'DESC' },
+        emptyFindResultsV2Filters(),
+      );
+      const mainSql = querySpy.mock.calls[1][0] as string;
+      expect(mainSql).toContain('ORDER BY r.title DESC');
+      expect(querySpy.mock.calls[1][1]).toEqual([5, 5]);
+    });
+
+    it('returns pagination metadata from count query', async () => {
+      querySpy
+        .mockResolvedValueOnce([{ total: 25 }])
+        .mockResolvedValueOnce([{ result_id: 1 }, { result_id: 2 }]);
+      const out = await repository.findResultsV2(
+        '',
+        { page: 2, limit: 10 },
+        undefined,
+        emptyFindResultsV2Filters(),
+      );
+      expect(out.pagination).toEqual({
+        total: 25,
+        page: 2,
+        limit: 10,
+        pageSize: 2,
+        totalPages: 3,
+        hasNextPage: true,
+        hasPreviousPage: true,
+      });
     });
   });
 });

--- a/server/researchindicators/src/domain/entities/results/repositories/result.repository.spec.ts
+++ b/server/researchindicators/src/domain/entities/results/repositories/result.repository.spec.ts
@@ -424,21 +424,29 @@ describe('ResultRepository', () => {
 
   describe('findResultsV2', () => {
     it('joins result_oicrs and selects cgspace_link', async () => {
-      querySpy
-        .mockResolvedValueOnce([{ total: 0 }])
-        .mockResolvedValueOnce([]);
-      await repository.findResultsV2('', undefined, undefined, emptyFindResultsV2Filters());
+      querySpy.mockResolvedValueOnce([{ total: 0 }]).mockResolvedValueOnce([]);
+      await repository.findResultsV2(
+        '',
+        undefined,
+        undefined,
+        emptyFindResultsV2Filters(),
+      );
       const mainSql = querySpy.mock.calls[1][0] as string;
-      expect(mainSql).toContain('LEFT JOIN result_oicrs ro ON ro.result_id = r.result_id');
+      expect(mainSql).toContain(
+        'LEFT JOIN result_oicrs ro ON ro.result_id = r.result_id',
+      );
       expect(mainSql).toContain('ro.cgspace_link');
       expect(mainSql).toMatch(/IF\([\s\S]*AS public_link/);
     });
 
     it('omits search fragments when search is empty', async () => {
-      querySpy
-        .mockResolvedValueOnce([{ total: 0 }])
-        .mockResolvedValueOnce([]);
-      await repository.findResultsV2('', undefined, undefined, emptyFindResultsV2Filters());
+      querySpy.mockResolvedValueOnce([{ total: 0 }]).mockResolvedValueOnce([]);
+      await repository.findResultsV2(
+        '',
+        undefined,
+        undefined,
+        emptyFindResultsV2Filters(),
+      );
       const countSql = querySpy.mock.calls[0][0] as string;
       const mainSql = querySpy.mock.calls[1][0] as string;
       expect(countSql).not.toContain('ro.cgspace_link LIKE');
@@ -450,9 +458,13 @@ describe('ResultRepository', () => {
     it('includes public_link and cgspace_link search with aligned placeholder counts', async () => {
       const search = '10568/12345';
       const staticWhereCount =
-        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT'];
+        ResultRepository[
+          'FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT'
+        ];
       const staticRelevanceCount =
-        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT'];
+        ResultRepository[
+          'FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT'
+        ];
       querySpy
         .mockResolvedValueOnce([{ total: 1 }])
         .mockResolvedValueOnce([{ result_id: 1, _search_relevance: 500 }]);
@@ -474,9 +486,9 @@ describe('ResultRepository', () => {
       expect(mainParams).toHaveLength(
         staticRelevanceCount + staticWhereCount + 4 + 2,
       );
-      expect(mainParams.slice(0, staticRelevanceCount).every((p) => p === search)).toBe(
-        true,
-      );
+      expect(
+        mainParams.slice(0, staticRelevanceCount).every((p) => p === search),
+      ).toBe(true);
       expect(
         mainParams
           .slice(staticRelevanceCount, staticRelevanceCount + staticWhereCount)
@@ -487,12 +499,14 @@ describe('ResultRepository', () => {
 
     it('binds creator-name tokens separately for multi-word search', async () => {
       const staticWhereCount =
-        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT'];
+        ResultRepository[
+          'FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT'
+        ];
       const staticRelevanceCount =
-        ResultRepository['FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT'];
-      querySpy
-        .mockResolvedValueOnce([{ total: 0 }])
-        .mockResolvedValueOnce([]);
+        ResultRepository[
+          'FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT'
+        ];
+      querySpy.mockResolvedValueOnce([{ total: 0 }]).mockResolvedValueOnce([]);
       await repository.findResultsV2(
         'john doe',
         undefined,
@@ -506,17 +520,23 @@ describe('ResultRepository', () => {
 
       expect(countSql).toContain('su.first_name LIKE');
       expect(countParams).toHaveLength(staticWhereCount + 4);
-      expect(countParams.slice(0, staticWhereCount).every((p) => p === 'john doe')).toBe(
-        true,
-      );
+      expect(
+        countParams.slice(0, staticWhereCount).every((p) => p === 'john doe'),
+      ).toBe(true);
       expect(countParams.slice(creatorWhereOffset)).toEqual([
         'john',
         'john',
         'doe',
         'doe',
       ]);
-      expect(mainParams.slice(11, 15)).toEqual(['john', 'john', 'doe', 'doe']);
-      expect(mainParams.slice(25, 29)).toEqual(['john', 'john', 'doe', 'doe']);
+      const creatorRelevanceEnd = staticRelevanceCount + 4;
+      const creatorWhereStart = creatorRelevanceEnd + staticWhereCount;
+      expect(
+        mainParams.slice(staticRelevanceCount, creatorRelevanceEnd),
+      ).toEqual(['john', 'john', 'doe', 'doe']);
+      expect(
+        mainParams.slice(creatorWhereStart, creatorWhereStart + 4),
+      ).toEqual(['john', 'john', 'doe', 'doe']);
     });
 
     it('strips _search_relevance from returned rows when search is provided', async () => {
@@ -536,9 +556,7 @@ describe('ResultRepository', () => {
     });
 
     it('applies onlyOwnResults filter in SQL', async () => {
-      querySpy
-        .mockResolvedValueOnce([{ total: 0 }])
-        .mockResolvedValueOnce([]);
+      querySpy.mockResolvedValueOnce([{ total: 0 }]).mockResolvedValueOnce([]);
       const filters = emptyFindResultsV2Filters();
       filters.currentUser.onlyOwnResults = true;
       await repository.findResultsV2('', undefined, undefined, filters);
@@ -547,9 +565,7 @@ describe('ResultRepository', () => {
     });
 
     it('uses custom sort when search is absent', async () => {
-      querySpy
-        .mockResolvedValueOnce([{ total: 0 }])
-        .mockResolvedValueOnce([]);
+      querySpy.mockResolvedValueOnce([{ total: 0 }]).mockResolvedValueOnce([]);
       await repository.findResultsV2(
         '',
         { page: 2, limit: 5 },

--- a/server/researchindicators/src/domain/entities/results/repositories/result.repository.ts
+++ b/server/researchindicators/src/domain/entities/results/repositories/result.repository.ts
@@ -20,7 +20,8 @@ import { IndicatorsEnum } from '../../indicators/enum/indicators.enum';
 @Injectable()
 export class ResultRepository
   extends Repository<Result>
-  implements ElasticFindEntity<ResultOpensearchDto> {
+  implements ElasticFindEntity<ResultOpensearchDto>
+{
   constructor(
     private readonly appConfig: AppConfig,
     private readonly currentUserUtil: CurrentUserUtil,
@@ -211,10 +212,11 @@ export class ResultRepository
 											  'start_date', ac.start_date,
 											  'deleted_at', ac.deleted_at))`;
 
-      queryParts.contracts.select = `,${filters?.primary_contract
-        ? `if(rc.result_contract_id is not null, ${tempQuery}, null)`
-        : `JSON_ARRAYAGG(COALESCE(${tempQuery}))`
-        } as result_contracts`;
+      queryParts.contracts.select = `,${
+        filters?.primary_contract
+          ? `if(rc.result_contract_id is not null, ${tempQuery}, null)`
+          : `JSON_ARRAYAGG(COALESCE(${tempQuery}))`
+      } as result_contracts`;
 
       if (filters?.primary_contract) {
         queryParts.contracts.groupBy = `,rc.result_contract_id`;
@@ -772,8 +774,8 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
 
     const staticWhereParams = search
       ? Array(
-        ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT,
-      ).fill(search)
+          ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT,
+        ).fill(search)
       : [];
     const creatorNameWhereParams = creatorNameTokens.flatMap((t) => [t, t]);
     const searchWhereParams = search
@@ -785,11 +787,11 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       : '';
     const relevanceParams = search
       ? [
-        ...Array(
-          ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT,
-        ).fill(search),
-        ...creatorNameTokens.flatMap((t) => [t, t]),
-      ]
+          ...Array(
+            ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT,
+          ).fill(search),
+          ...creatorNameTokens.flatMap((t) => [t, t]),
+        ]
       : [];
 
     const fromAndJoins = `
@@ -873,9 +875,9 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
     const rawData = await this.query(mainQuery, mainQueryParams);
     const data = search
       ? rawData.map((row: Record<string, unknown>) => {
-        const { _search_relevance: _r, ...rest } = row;
-        return rest;
-      })
+          const { _search_relevance: _r, ...rest } = row;
+          return rest;
+        })
       : rawData;
 
     return {

--- a/server/researchindicators/src/domain/entities/results/repositories/result.repository.ts
+++ b/server/researchindicators/src/domain/entities/results/repositories/result.repository.ts
@@ -20,8 +20,7 @@ import { IndicatorsEnum } from '../../indicators/enum/indicators.enum';
 @Injectable()
 export class ResultRepository
   extends Repository<Result>
-  implements ElasticFindEntity<ResultOpensearchDto>
-{
+  implements ElasticFindEntity<ResultOpensearchDto> {
   constructor(
     private readonly appConfig: AppConfig,
     private readonly currentUserUtil: CurrentUserUtil,
@@ -212,11 +211,10 @@ export class ResultRepository
 											  'start_date', ac.start_date,
 											  'deleted_at', ac.deleted_at))`;
 
-      queryParts.contracts.select = `,${
-        filters?.primary_contract
-          ? `if(rc.result_contract_id is not null, ${tempQuery}, null)`
-          : `JSON_ARRAYAGG(COALESCE(${tempQuery}))`
-      } as result_contracts`;
+      queryParts.contracts.select = `,${filters?.primary_contract
+        ? `if(rc.result_contract_id is not null, ${tempQuery}, null)`
+        : `JSON_ARRAYAGG(COALESCE(${tempQuery}))`
+        } as result_contracts`;
 
       if (filters?.primary_contract) {
         queryParts.contracts.groupBy = `,rc.result_contract_id`;
@@ -580,12 +578,47 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
     return tokens.length > 0 ? tokens : [search];
   }
 
-  private static readonly FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT = 8;
+  private static readonly FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT = 10;
 
   /** Placeholders in buildFindResultsV2SearchRelevanceSelectFragment before creator-name CASEs. */
-  private static readonly FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT = 9;
+  private static readonly FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT = 11;
+  //TODO: This needs to be corrected once the PDF is complete.
+  /**
+   * Built URL for platforms that do not persist `public_link` (IF ELSE branch).
+   * Replace `return 'NULL'` with the final expression once base URL, path, and per-`platform_code` rules are defined.
+   *
+   * STAR reference (export): {@link StarResultsExportRepository.findStarResultsMetadataRows}
+   * `CONCAT_WS('', '${ARI_CLIENT_HOST}/result/STAR-', result_code, '/general-information')`
+   */
+  private buildFindResultsV2BuiltPublicLinkSqlExpression(): string {
+    // const host = this.appConfig.ARI_CLIENT_HOST;
+    // return `CASE r.platform_code
+    //   WHEN 'STAR' THEN CONCAT_WS(
+    //     '',
+    //     '${host}/result/',
+    //     r.result_official_code,
+    //     '/general-information'
+    //   )
+    //   -- WHEN 'OTHER_PLATFORM' THEN CONCAT_WS('', '${host}/...', r.result_official_code, '...')
+    //   ELSE NULL
+    // END`;
+    return 'NULL';
+  }
+
+  /**
+   * Effective `public_link` for findResultsV2. Reuse the same expression in SELECT, WHERE, and relevance.
+   * PRMS/TIP: `r.public_link` column; otherwise: {@link buildFindResultsV2BuiltPublicLinkSqlExpression}.
+   */
+  private buildFindResultsV2PublicLinkSqlExpression(): string {
+    return `IF(
+      r.platform_code IN ('PRMS', 'TIP'),
+      r.public_link,
+      ${this.buildFindResultsV2BuiltPublicLinkSqlExpression()}
+    )`;
+  }
 
   private buildFindResultsV2SearchStaticWhereFragment(): string {
+    const publicLinkExpr = this.buildFindResultsV2PublicLinkSqlExpression();
     return `
     AND ((
             r.report_year_id IN (?)
@@ -602,7 +635,9 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       OR i.name like CONCAT('%',?, '%')
       OR rs.name LIKE CONCAT('%',?, '%')
       OR rc.contract_id = ?
-      OR cl.short_name LIKE CONCAT('%',?, '%')`;
+      OR cl.short_name LIKE CONCAT('%',?, '%')
+      OR (${publicLinkExpr}) LIKE CONCAT('%',?, '%')
+      OR ro.cgspace_link LIKE CONCAT('%',?, '%')`;
   }
 
   /**
@@ -628,6 +663,7 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
   private buildFindResultsV2SearchRelevanceSelectFragment(
     creatorNameTokens: string[],
   ): string {
+    const publicLinkExpr = this.buildFindResultsV2PublicLinkSqlExpression();
     const nameRelevanceCases = creatorNameTokens.map(
       () =>
         `(CASE WHEN (su.first_name LIKE CONCAT('%', ?, '%') OR su.last_name LIKE CONCAT('%', ?, '%')) THEN 220 ELSE 0 END)`,
@@ -649,6 +685,8 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       (CASE WHEN rs.name LIKE CONCAT('%', ?, '%') THEN 380 ELSE 0 END) +
       (CASE WHEN rc.contract_id = ? THEN 750 ELSE 0 END) +
       (CASE WHEN cl.short_name LIKE CONCAT('%', ?, '%') THEN 320 ELSE 0 END) +
+      (CASE WHEN (${publicLinkExpr}) LIKE CONCAT('%', ?, '%') THEN 500 ELSE 0 END) +
+      (CASE WHEN ro.cgspace_link LIKE CONCAT('%', ?, '%') THEN 500 ELSE 0 END) +
       ${nameRelevanceCases}
     ) AS _search_relevance`;
   }
@@ -734,8 +772,8 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
 
     const staticWhereParams = search
       ? Array(
-          ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT,
-        ).fill(search)
+        ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_WHERE_PLACEHOLDER_COUNT,
+      ).fill(search)
       : [];
     const creatorNameWhereParams = creatorNameTokens.flatMap((t) => [t, t]);
     const searchWhereParams = search
@@ -747,11 +785,11 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       : '';
     const relevanceParams = search
       ? [
-          ...Array(
-            ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT,
-          ).fill(search),
-          ...creatorNameTokens.flatMap((t) => [t, t]),
-        ]
+        ...Array(
+          ResultRepository.FIND_RESULTS_V2_SEARCH_STATIC_RELEVANCE_PLACEHOLDER_COUNT,
+        ).fill(search),
+        ...creatorNameTokens.flatMap((t) => [t, t]),
+      ]
       : [];
 
     const fromAndJoins = `
@@ -769,7 +807,8 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       AND rl.is_active = TRUE
       AND rl.is_primary = TRUE
     LEFT JOIN sec_users su ON su.sec_user_id = r.created_by
-    LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id`;
+    LEFT JOIN clarisa_levers cl ON cl.id = rl.lever_id
+    LEFT JOIN result_oicrs ro ON ro.result_id = r.result_id`;
 
     const countQuery = `
     SELECT COUNT(tmp.total) AS total FROM (SELECT COUNT(DISTINCT r.result_id) AS total
@@ -780,7 +819,6 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       ${search ? searchConditions : ''}
     GROUP BY r.result_id
     ORDER BY r.result_official_code ASC) tmp`;
-
     const mainQuery = `
     SELECT
       r.created_at,
@@ -795,11 +833,12 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
       r.title,
       r.indicator_id,
       r.external_link,
-      r.public_link,
+      ${this.buildFindResultsV2PublicLinkSqlExpression()} AS public_link,
       i.name AS indicator_name,
       r.result_status_id AS status_id,
       rs.name AS status_name,
       rs.config as status_config,
+      ro.cgspace_link,
       GROUP_CONCAT(DISTINCT r2.report_year_id ORDER BY r2.report_year_id DESC) AS snapshot_years,
       rc.contract_id,
       ac.description as contract_description,
@@ -834,9 +873,9 @@ GROUP BY rl.result_id) tmp_rl ON tmp_rl.result_id = r.result_id`;
     const rawData = await this.query(mainQuery, mainQueryParams);
     const data = search
       ? rawData.map((row: Record<string, unknown>) => {
-          const { _search_relevance: _r, ...rest } = row;
-          return rest;
-        })
+        const { _search_relevance: _r, ...rest } = row;
+        return rest;
+      })
       : rawData;
 
     return {

--- a/server/researchindicators/src/domain/entities/results/results.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/results/results.controller.spec.ts
@@ -93,10 +93,12 @@ describe('ResultsController', () => {
           provide: DataSource,
           useValue: mockDataSource,
         },
-        ResultStatusGuard,
         SetUpInterceptor,
       ],
-    }).compile();
+    })
+      .overrideGuard(ResultStatusGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .compile();
 
     controller = module.get<ResultsController>(ResultsController);
     service = module.get(ResultsService);

--- a/server/researchindicators/src/domain/shared/guards/result-status.guard.spec.ts
+++ b/server/researchindicators/src/domain/shared/guards/result-status.guard.spec.ts
@@ -1,30 +1,111 @@
-import { BadRequestException } from '@nestjs/common';
-import { ExecutionContext } from '@nestjs/common';
+import { BadRequestException, ExecutionContext } from '@nestjs/common';
 import { ResultStatusGuard } from './result-status.guard';
 import { ResultStatusEnum } from '../../entities/result-status/enum/result-status.enum';
+import { SecRolesEnum } from '../enum/sec_role.enum';
 
 describe('ResultStatusGuard', () => {
-  const setup = (result_status_id: number) => {
-    const findOne = jest.fn().mockResolvedValue({ result_status_id });
+  const createGuard = (options: {
+    result_status_id?: number;
+    roles?: SecRolesEnum[];
+    findOneResult?: { result_status_id: number } | null;
+  }) => {
+    const {
+      result_status_id = ResultStatusEnum.DRAFT,
+      roles = [],
+      findOneResult,
+    } = options;
+
+    const findOne = jest
+      .fn()
+      .mockResolvedValue(findOneResult ?? { result_status_id });
     const getRepository = jest.fn().mockReturnValue({ findOne });
     const dataSource = { getRepository } as any;
     const resultsUtil = {
       setup: jest.fn().mockResolvedValue(undefined),
       resultId: 1,
     } as any;
-    const guard = new ResultStatusGuard(dataSource, resultsUtil);
-    return { guard, findOne, getRepository, resultsUtil };
+    const currentUserUtil = {
+      user: { roles },
+    } as any;
+
+    const guard = new ResultStatusGuard(
+      dataSource,
+      resultsUtil,
+      currentUserUtil,
+    );
+
+    return { guard, findOne, resultsUtil, currentUserUtil };
   };
 
-  it('should allow editable statuses', async () => {
-    const { guard } = setup(ResultStatusEnum.DRAFT);
-    await expect(guard.canActivate({} as ExecutionContext)).resolves.toBe(true);
+  const context = {} as ExecutionContext;
+
+  describe('editable statuses', () => {
+    const editableStatuses = [
+      ResultStatusEnum.DRAFT,
+      ResultStatusEnum.REVISED,
+      ResultStatusEnum.SCIENCE_EDITION,
+      ResultStatusEnum.KM_CURATION,
+    ];
+
+    it.each(editableStatuses)(
+      'should allow editing when result status is %s',
+      async (statusId) => {
+        const { guard, findOne } = createGuard({ result_status_id: statusId });
+
+        await expect(guard.canActivate(context)).resolves.toBe(true);
+        expect(findOne).toHaveBeenCalled();
+      },
+    );
   });
 
   it('should reject non-editable status', async () => {
-    const { guard } = setup(ResultStatusEnum.SUBMITTED);
-    await expect(guard.canActivate({} as ExecutionContext)).rejects.toThrow(
+    const { guard } = createGuard({
+      result_status_id: ResultStatusEnum.SUBMITTED,
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
       BadRequestException,
     );
+  });
+
+  describe('role bypass', () => {
+    const bypassRoles = [
+      SecRolesEnum.SYSTEM_ADMIN,
+      SecRolesEnum.TECHNICAL_SUPPORT,
+      SecRolesEnum.CENTER_ADMIN,
+    ];
+
+    it.each(bypassRoles)(
+      'should bypass status check for role %s',
+      async (role) => {
+        const { guard, findOne } = createGuard({
+          result_status_id: ResultStatusEnum.SUBMITTED,
+          roles: [role],
+        });
+
+        await expect(guard.canActivate(context)).resolves.toBe(true);
+        expect(findOne).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should not bypass status check for non-privileged roles', async () => {
+      const { guard, findOne } = createGuard({
+        result_status_id: ResultStatusEnum.SUBMITTED,
+        roles: [SecRolesEnum.CONTRIBUTOR],
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(findOne).toHaveBeenCalled();
+    });
+  });
+
+  it('should call resultsUtil.setup before validation', async () => {
+    const { guard, resultsUtil } = createGuard({});
+
+    await guard.canActivate(context);
+
+    expect(resultsUtil.setup).toHaveBeenCalled();
   });
 });

--- a/server/researchindicators/src/domain/shared/guards/result-status.guard.ts
+++ b/server/researchindicators/src/domain/shared/guards/result-status.guard.ts
@@ -11,17 +11,35 @@ import {
   ResultStatusNameEnum,
 } from '../../entities/result-status/enum/result-status.enum';
 import { ResultsUtil } from '../utils/results.util';
+import { CurrentUserUtil } from '../utils/current-user.util';
+import { SecRolesEnum } from '../enum/sec_role.enum';
 
 @Injectable()
 export class ResultStatusGuard implements CanActivate {
   constructor(
     private readonly dataSource: DataSource,
     private readonly _resultsUtil: ResultsUtil,
+    private readonly _currentUserUtil: CurrentUserUtil,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async canActivate(context: ExecutionContext): Promise<boolean> {
     await this._resultsUtil.setup();
+
+    const bypassRoles = [
+      SecRolesEnum.SYSTEM_ADMIN,
+      SecRolesEnum.TECHNICAL_SUPPORT,
+      SecRolesEnum.CENTER_ADMIN,
+    ];
+
+    if (
+      this._currentUserUtil.user.roles.some((role) =>
+        bypassRoles.includes(role),
+      )
+    ) {
+      return true;
+    }
+
     const result = await this.dataSource.getRepository(Result).findOne({
       where: {
         result_id: this._resultsUtil.resultId,
@@ -35,7 +53,6 @@ export class ResultStatusGuard implements CanActivate {
         ResultStatusEnum.REVISED,
         ResultStatusEnum.SCIENCE_EDITION,
         ResultStatusEnum.KM_CURATION,
-        ResultStatusEnum.PUBLISHED,
       ].includes(result.result_status_id)
     ) {
       throw new BadRequestException(
@@ -44,7 +61,6 @@ export class ResultStatusGuard implements CanActivate {
           ResultStatusNameEnum[ResultStatusEnum.REVISED],
           ResultStatusNameEnum[ResultStatusEnum.SCIENCE_EDITION],
           ResultStatusNameEnum[ResultStatusEnum.KM_CURATION],
-          ResultStatusNameEnum[ResultStatusEnum.PUBLISHED],
         ].join(', ')} status can be edited`,
       );
     }

--- a/server/researchindicators/src/domain/shared/utils/timestamp-date.util.spec.ts
+++ b/server/researchindicators/src/domain/shared/utils/timestamp-date.util.spec.ts
@@ -43,9 +43,9 @@ describe('parseCapacitySharingTimestamp', () => {
   });
 
   it('should throw for unsupported value types', () => {
-    expect(() =>
-      parseCapacitySharingTimestamp(true, 'start_date'),
-    ).toThrow(BadRequestException);
+    expect(() => parseCapacitySharingTimestamp(true, 'start_date')).toThrow(
+      BadRequestException,
+    );
   });
 
   it('should parse ISO string with Z', () => {

--- a/server/researchindicators/src/domain/shared/utils/timestamp-date.util.ts
+++ b/server/researchindicators/src/domain/shared/utils/timestamp-date.util.ts
@@ -2,8 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 
 const TIMESTAMP_FORMAT = {
   isoZ: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z?$/,
-  isoOffset:
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?[+-]\d{2}:\d{2}$/,
+  isoOffset: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?[+-]\d{2}:\d{2}$/,
   mysql: /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(\.\d{1,6})?$/,
   dateOnly: /^\d{4}-\d{2}-\d{2}$/,
 } as const;
@@ -34,10 +33,7 @@ const isValidCapacitySharingTimestampString = (value: string): boolean =>
 const invalidTimestampException = (fieldName: string): BadRequestException =>
   new BadRequestException(`Invalid ${fieldName}: not a valid timestamp`);
 
-const parseValidDate = (
-  value: Date | number,
-  fieldName: string,
-): Date => {
+const parseValidDate = (value: Date | number, fieldName: string): Date => {
   const parsed = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(parsed.getTime())) {
     throw invalidTimestampException(fieldName);


### PR DESCRIPTION
# Release Summary

This release consolidates three backend ARI workstreams focused on the OICR indicator and result edit governance.

## Scope

The release groups three main tickets:

- **AC-1634**: backend service adjustments for `cgspace_link`, Result Center search (`findResultsV2`), and STAR export fixes.
- **AC-1635**: edit permissions by role, allowing administrators to edit results outside the normally editable statuses.
- **AC-1636**: OICR workflow updates, including validation on status transitions and revised green-check rules.

Related work also includes **AC-1549**, which partially updated OICR columns in the STAR Results Excel export.

## Changes by area

### 1. `cgspace_link` field on OICR

**Migration:** `1780074063394-AddedCGSpaceLink.ts`

- Adds a new nullable text column, `cgspace_link`, to `result_oicrs`.
- Exposes the field in entities, DTOs, and services:
  - `result-oicr.entity.ts`
  - `create-result-oicr.dto.ts`
  - `result-evidences.service.ts`
  - `create-result-evidence.dto.ts`
  - `result-oicr.service.ts`
- When evidences are updated for an OICR result, notable references are upserted and the CGSpace link is saved in `result_oicrs.cgspace_link`.
- The evidence-step response now returns `cgspace_link` for OICR indicators.

### 2. Green checks and OICR validation

**Migrations:**

- `1780519377343-UpdateOicrGreen.ts`
- `1780342254980-AddedValidationGreenFunction.ts`
- `1780590538118-UpdateOICRview.ts`
- `1780672573009-UpdateOicrLinkResult.ts`

Key updates:

- Recreates the MySQL function `oicr_validation` and now requires `valid_text(ro.cgspace_link)` for the OICR indicator (`id = 5`).
- Assigns the `completenessValidation` action to workflow `id 37`.
- Updates the `report_oicr` view so the `existing_oicr` column comes from `TEMP_result_external_oicrs`.
- Further refines the `report_oicr` view.
- OICR completeness validation now requires a valid CGSpace link before the green check passes.

### 3. Status workflow: `is_status_change_validation_required`

**Migration:** `1780331976405-AddedValidationColumn.ts`

- Adds a new column, `is_status_change_validation_required`, to `result_status_workflow` with default value `0`.
- Sets the flag to `1` for transitions with ids: `1, 6, 7, 12, 13, 18, 19, 24, 25, 30, 37`.
- Exposes the flag through:
  - `ResultStatusWorkflowService.getConfigWorkflowByIndicatorAndFromStatus`
  - `getNextStepsByResultId`
- This allows clients to determine whether validation must run before changing status.

Relevant mapping logic:

```ts
return toStatusIds
  .map((toId) => statusById.get(toId))
  .filter((s) => !!s)
  .map((s) => ({
    ...s,
    transition_direction: this.getTransitionDirection(
      fromStatusId,
      s.result_status_id,
      depthMap,
    ),
    is_status_change_validation_required:
      workflowByToStatusId.get(s.result_status_id)
        ?.is_status_change_validation_required ?? false,
  }));
```

### 4. Role-based edit permissions: `ResultStatusGuard`

**File:** `domain/shared/guards/result-status.guard.ts`

Roles that bypass editable-status restrictions:

- `SYSTEM_ADMIN`
- `TECHNICAL_SUPPORT`
- `CENTER_ADMIN`

For all other roles, mutations are allowed only when the result is in these statuses:

- `DRAFT` (`4`)
- `REVISED` (`5`)
- `SCIENCE_EDITION` (`12`)
- `KM_CURATION` (`13`)

Controllers that add `ResultStatusGuard` in this release:

- `link-results.controller.ts`
- `result-cap-sharing-ip.controller.ts`
- `result-innovation-dev.controller.ts`
- `result-ip-rights.controller.ts`

Other controllers already had the guard, and this release expands that coverage.

### 5. Result Center search: `findResultsV2`

**File:** `domain/entities/results/repositories/result.repository.ts`

- Adds `LEFT JOIN result_oicrs ro` to `findResultsV2` queries.
- Includes a new response field: `ro.cgspace_link`.
- Extends text search to match:
  - effective `public_link`
  - `ro.cgspace_link`
- Adds `+500` relevance points for matches on `public_link` or `cgspace_link`.

Technical note:

- `buildFindResultsV2BuiltPublicLinkSqlExpression()` currently returns `NULL` until the final STAR URL is defined.
- The code includes a `TODO` referencing `ARI_CLIENT_HOST`.

### 6. STAR Results export: OICR columns

**Files:**

- `star-results-metadata.columns.ts`
- `star-results-export.repository.ts`

Updates:

- The **Existing OICR** column now maps to `existing_oicr` instead of `general_comment`.
- The export query now selects `oc.existing_oicr` from the `report_oicr` view.
- This fixes the incorrect Excel export mapping where general comments appeared as **Existing OICR**.

## Database migrations

Run these migrations in order:

1. `1780074063394-AddedCGSpaceLink.ts`
2. `1780331976405-AddedValidationColumn.ts`
3. `1780342254980-AddedValidationGreenFunction.ts`
4. `1780519377343-UpdateOicrGreen.ts`
5. `1780590538118-UpdateOICRview.ts`
6. `1780672573009-UpdateOicrLinkResult.ts`

**Deployment requirement:** run migrations before starting the new API version.

```bash
cd server/researchindicators
npm run migration:dev:execute   # development
# or
npm run migration:execute       # production (against dist)
```

## API and consumer impact

| Endpoint / flow | Change |
|---|---|
| `PUT` OICR evidences | Accepts and persists `cgspace_link` in the request body. |
| `GET` OICR evidences | Returns `cgspace_link` from `result_oicrs`. |
| `GET` next steps / workflow config | Returns `is_status_change_validation_required` per destination status. |
| `GET` Result Center v2 | Includes `cgspace_link` in the response and supports search by CGSpace and public link. |
| Mutations on guarded controllers | Admin roles can edit in any status. |
| STAR metadata Excel export | **Existing OICR** shows `existing_oicr` correctly. |

## Test coverage

Unit and controller coverage was expanded in:

- `result-status.guard.spec.ts` — role bypass and editable statuses.
- `result-status-workflow.service.spec.ts` — `is_status_change_validation_required` flag.
- `result-evidences.service.spec.ts` — `cgspace_link` persistence and retrieval.
- `result-oicr.service.spec.ts` — `cgspace_link` in the evidence step.
- `result.repository.spec.ts` — SQL helpers and `findResultsV2` (`+236` lines of tests).
- Controller specs impacted by `ResultStatusGuard`.

```bash
cd server/researchindicators
npm test
npm run test:cov
```