### PR TITLE
Implement and enhance AppConfigController and AppConfigService methods

### DIFF
--- a/server/researchindicators/src/domain/entities/app-config/app-config.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.controller.spec.ts
@@ -11,6 +11,7 @@ describe('AppConfigController', () => {
   let controller: AppConfigController;
   const mockService = {
     findConfigByKey: jest.fn(),
+    getAllConfigs: jest.fn(),
     updateConfig: jest.fn(),
   };
   const mockFormat = jest.fn();
@@ -30,6 +31,34 @@ describe('AppConfigController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('getAllConfigs', async () => {
+    const rows = [{ key: 'a' }];
+    mockService.getAllConfigs.mockResolvedValue(rows);
+    mockFormat.mockReturnValue({});
+
+    await controller.getAllConfigs(
+      'email',
+      'EMAIL',
+      'READINESS_LEVEL_7',
+      '2',
+      '10',
+      'key' as any,
+      'DESC',
+    );
+
+    expect(mockService.getAllConfigs).toHaveBeenCalledWith(
+      { category: 'EMAIL', subcategory: 'READINESS_LEVEL_7' },
+      { field: 'key', order: 'DESC' },
+      { page: 2, limit: 10 },
+      'email',
+    );
+    expect(ResponseUtils.format).toHaveBeenCalledWith({
+      data: rows,
+      description: 'Configurations retrieved successfully',
+      status: HttpStatus.OK,
+    });
   });
 
   it('getConfigByKey', async () => {

--- a/server/researchindicators/src/domain/entities/app-config/app-config.controller.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.controller.spec.ts
@@ -34,8 +34,19 @@ describe('AppConfigController', () => {
   });
 
   it('getAllConfigs', async () => {
-    const rows = [{ key: 'a' }];
-    mockService.getAllConfigs.mockResolvedValue(rows);
+    const payload = {
+      data: [{ key: 'a' }],
+      pagination: {
+        total: 1,
+        page: 2,
+        limit: 10,
+        pageSize: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      },
+    };
+    mockService.getAllConfigs.mockResolvedValue(payload);
     mockFormat.mockReturnValue({});
 
     await controller.getAllConfigs(
@@ -55,10 +66,32 @@ describe('AppConfigController', () => {
       'email',
     );
     expect(ResponseUtils.format).toHaveBeenCalledWith({
-      data: rows,
+      data: payload,
       description: 'Configurations retrieved successfully',
       status: HttpStatus.OK,
     });
+  });
+
+  it('getAllConfigs without limit ignores page query param', async () => {
+    mockService.getAllConfigs.mockResolvedValue({ data: [], pagination: {} });
+    mockFormat.mockReturnValue({});
+
+    await controller.getAllConfigs(
+      undefined,
+      undefined,
+      undefined,
+      '3',
+      undefined,
+      'key' as any,
+      'ASC',
+    );
+
+    expect(mockService.getAllConfigs).toHaveBeenCalledWith(
+      { category: undefined, subcategory: undefined },
+      { field: 'key', order: 'ASC' },
+      undefined,
+      undefined,
+    );
   });
 
   it('getConfigByKey', async () => {

--- a/server/researchindicators/src/domain/entities/app-config/app-config.controller.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.controller.ts
@@ -58,13 +58,14 @@ export class AppConfigController {
     name: 'page',
     required: false,
     type: Number,
-    description: 'Page number (1-based)',
+    description: 'Page number (1-based). Only applies when limit is set.',
   })
   @ApiQuery({
     name: 'limit',
     required: false,
     type: Number,
-    description: 'Maximum number of items per page',
+    description:
+      'Maximum number of items per page. When omitted, all matching rows are returned.',
   })
   @ApiQuery({
     name: 'sort-field',
@@ -90,14 +91,18 @@ export class AppConfigController {
     @Query('sort-order', new DefaultValuePipe('ASC'))
     sortOrder?: 'ASC' | 'DESC',
   ) {
-    const pageNumber = page ? Number(page) : undefined;
     const limitNumber = limit ? Number(limit) : undefined;
+    const hasValidLimit =
+      limitNumber !== undefined &&
+      !Number.isNaN(limitNumber) &&
+      limitNumber > 0;
+    const pageNumber = hasValidLimit && page ? Number(page) : undefined;
 
     return this.appConfigService
       .getAllConfigs(
         { category, subcategory },
         { field: sortField, order: sortOrder },
-        { page: pageNumber, limit: limitNumber },
+        hasValidLimit ? { page: pageNumber, limit: limitNumber } : undefined,
         search,
       )
       .then((data) =>

--- a/server/researchindicators/src/domain/entities/app-config/app-config.controller.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.controller.ts
@@ -1,19 +1,31 @@
 import {
   Body,
   Controller,
+  DefaultValuePipe,
   Get,
   HttpStatus,
   Param,
   Patch,
+  Query,
   UseGuards,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { AppConfigService } from './app-config.service';
 import { ResponseUtils } from '../../shared/utils/response.utils';
-import { AppConfig } from './entities/app-config.entity';
-import { ApiBearerAuth, ApiBody, ApiParam, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { RolesGuard } from '../../shared/guards/roles.guard';
 import { Roles } from '../../shared/decorators/roles.decorator';
 import { SecRolesEnum } from '../../shared/enum/sec_role.enum';
+import { UpdateAppConfigDto } from './dtos/update-app-config.dto';
+import { AppConfigSorting } from './enum/app-config-forting.enum';
 
 @ApiTags('Configuration')
 @ApiBearerAuth()
@@ -22,10 +34,98 @@ import { SecRolesEnum } from '../../shared/enum/sec_role.enum';
 export class AppConfigController {
   constructor(private readonly appConfigService: AppConfigService) {}
 
+  @Get()
+  @ApiOperation({ summary: 'List application configuration entries' })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description: 'Text search across key, category, values, and updater name',
+  })
+  @ApiQuery({
+    name: 'category',
+    required: false,
+    type: String,
+    description: 'Filter by configuration category',
+  })
+  @ApiQuery({
+    name: 'subcategory',
+    required: false,
+    type: String,
+    description: 'Filter by configuration subcategory',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page number (1-based)',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Maximum number of items per page',
+  })
+  @ApiQuery({
+    name: 'sort-field',
+    required: false,
+    enum: AppConfigSorting,
+    description:
+      'Field used for secondary sort (primary sort is relevance when search is set)',
+  })
+  @ApiQuery({
+    name: 'sort-order',
+    required: false,
+    enum: ['ASC', 'DESC'],
+    description: 'Sort direction for sort-field',
+  })
+  async getAllConfigs(
+    @Query('search') search?: string,
+    @Query('category') category?: string,
+    @Query('subcategory') subcategory?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('sort-field', new DefaultValuePipe(AppConfigSorting.KEY))
+    sortField?: AppConfigSorting,
+    @Query('sort-order', new DefaultValuePipe('ASC'))
+    sortOrder?: 'ASC' | 'DESC',
+  ) {
+    const pageNumber = page ? Number(page) : undefined;
+    const limitNumber = limit ? Number(limit) : undefined;
+
+    return this.appConfigService
+      .getAllConfigs(
+        { category, subcategory },
+        { field: sortField, order: sortOrder },
+        { page: pageNumber, limit: limitNumber },
+        search,
+      )
+      .then((data) =>
+        ResponseUtils.format({
+          data,
+          description: 'Configurations retrieved successfully',
+          status: HttpStatus.OK,
+        }),
+      );
+  }
+
+  @Get('categories-and-subcategories')
+  @ApiOperation({ summary: 'Get all categories and subcategories' })
+  async getCategoriesAndSubcategories() {
+    return this.appConfigService.getCategoriesAndSubcategories().then((data) =>
+      ResponseUtils.format({
+        data,
+        description: 'Categories and subcategories retrieved successfully',
+        status: HttpStatus.OK,
+      }),
+    );
+  }
+
   @Get(':key')
+  @ApiOperation({ summary: 'Get a configuration entry by key' })
   @ApiParam({
     name: 'key',
-    description: 'The key of the configuration to update',
+    description: 'The key of the configuration to retrieve',
     type: String,
   })
   async getConfigByKey(@Param('key') key: string) {
@@ -40,7 +140,7 @@ export class AppConfigController {
 
   @Patch(':key')
   @ApiBody({
-    type: AppConfig,
+    type: UpdateAppConfigDto,
     description: 'Configuration data to update',
   })
   @ApiParam({
@@ -48,10 +148,17 @@ export class AppConfigController {
     description: 'The key of the configuration to update',
     type: String,
   })
-  @Roles(SecRolesEnum.TECHNICAL_SUPPORT)
+  @Roles(SecRolesEnum.TECHNICAL_SUPPORT, SecRolesEnum.SYSTEM_ADMIN)
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  )
   async updateConfig(
     @Param('key') key: string,
-    @Body() updateData: Partial<AppConfig>,
+    @Body() updateData: Partial<UpdateAppConfigDto>,
   ) {
     return this.appConfigService.updateConfig(key, updateData).then((config) =>
       ResponseUtils.format({

--- a/server/researchindicators/src/domain/entities/app-config/app-config.module.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { AppConfigService } from './app-config.service';
 import { AppConfigController } from './app-config.controller';
 import { AppSecretsModule } from '../app-secrets/app-secrets.module';
+import { AppConfigRepository } from './repositories/app-config.repository';
 
 @Module({
   controllers: [AppConfigController],
-  providers: [AppConfigService],
+  providers: [AppConfigService, AppConfigRepository],
   imports: [AppSecretsModule],
-  exports: [AppConfigService],
+  exports: [AppConfigService, AppConfigRepository],
 })
 export class AppConfigModule {}

--- a/server/researchindicators/src/domain/entities/app-config/app-config.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.service.spec.ts
@@ -66,8 +66,19 @@ describe('AppConfigService', () => {
 
   describe('getAllConfigs', () => {
     it('should delegate to AppConfigRepository.findAll', async () => {
-      const rows = [{ key: 'k1' }] as AppConfig[];
-      mockAppConfigRepository.findAll.mockResolvedValue(rows);
+      const payload = {
+        data: [{ key: 'k1' }] as AppConfig[],
+        pagination: {
+          total: 1,
+          page: 1,
+          limit: 20,
+          pageSize: 1,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      };
+      mockAppConfigRepository.findAll.mockResolvedValue(payload);
 
       const result = await service.getAllConfigs(
         { category: 'EMAIL' },
@@ -82,7 +93,7 @@ describe('AppConfigService', () => {
         { page: 1, limit: 20 },
         'test',
       );
-      expect(result).toBe(rows);
+      expect(result).toBe(payload);
     });
 
     it('should default sorting to empty object when omitted', async () => {

--- a/server/researchindicators/src/domain/entities/app-config/app-config.service.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.service.spec.ts
@@ -4,6 +4,8 @@ import { DataSource } from 'typeorm';
 import { AppConfigService } from './app-config.service';
 import { AppConfig } from './entities/app-config.entity';
 import { CurrentUserUtil } from '../../shared/utils/current-user.util';
+import { AppConfigRepository } from './repositories/app-config.repository';
+import { AppConfigSorting } from './enum/app-config-forting.enum';
 
 describe('AppConfigService', () => {
   let service: AppConfigService;
@@ -19,7 +21,14 @@ describe('AppConfigService', () => {
     getRepository: jest.fn().mockReturnValue(mockRepository),
   };
 
-  const mockCurrentUser = { user: { id: 1 }, audit: jest.fn() };
+  const mockCurrentUser = {
+    user: { id: 1 },
+    audit: jest.fn().mockReturnValue({ updated_by: 1 }),
+  };
+  const mockAppConfigRepository = {
+    findAll: jest.fn(),
+    findAllCategoriesAndSubcategories: jest.fn(),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -29,6 +38,7 @@ describe('AppConfigService', () => {
         AppConfigService,
         { provide: DataSource, useValue: mockDataSource },
         { provide: CurrentUserUtil, useValue: mockCurrentUser },
+        { provide: AppConfigRepository, useValue: mockAppConfigRepository },
       ],
     }).compile();
 
@@ -51,6 +61,60 @@ describe('AppConfigService', () => {
         where: { key: 'feature.x', is_active: true },
       });
       expect(result).toBe(row);
+    });
+  });
+
+  describe('getAllConfigs', () => {
+    it('should delegate to AppConfigRepository.findAll', async () => {
+      const rows = [{ key: 'k1' }] as AppConfig[];
+      mockAppConfigRepository.findAll.mockResolvedValue(rows);
+
+      const result = await service.getAllConfigs(
+        { category: 'EMAIL' },
+        { field: AppConfigSorting.KEY, order: 'DESC' },
+        { page: 1, limit: 20 },
+        'test',
+      );
+
+      expect(mockAppConfigRepository.findAll).toHaveBeenCalledWith(
+        { category: 'EMAIL' },
+        { field: AppConfigSorting.KEY, order: 'DESC' },
+        { page: 1, limit: 20 },
+        'test',
+      );
+      expect(result).toBe(rows);
+    });
+
+    it('should default sorting to empty object when omitted', async () => {
+      mockAppConfigRepository.findAll.mockResolvedValue([]);
+
+      await service.getAllConfigs({ category: 'EMAIL' });
+
+      expect(mockAppConfigRepository.findAll).toHaveBeenCalledWith(
+        { category: 'EMAIL' },
+        {},
+        undefined,
+        undefined,
+      );
+    });
+  });
+
+  describe('getCategoriesAndSubcategories', () => {
+    it('should delegate to AppConfigRepository.findAllCategoriesAndSubcategories', async () => {
+      const lists = {
+        categories: ['EMAIL'],
+        subcategories: ['READINESS_LEVEL_7'],
+      };
+      mockAppConfigRepository.findAllCategoriesAndSubcategories.mockResolvedValue(
+        lists,
+      );
+
+      const result = await service.getCategoriesAndSubcategories();
+
+      expect(
+        mockAppConfigRepository.findAllCategoriesAndSubcategories,
+      ).toHaveBeenCalled();
+      expect(result).toBe(lists);
     });
   });
 
@@ -82,9 +146,13 @@ describe('AppConfigService', () => {
       expect(update).toHaveBeenCalledWith('k1', {
         description: 'new desc',
         simple_value: 'v',
+        json_value: undefined,
+        category: undefined,
+        subcategory: undefined,
+        updated_by: 1,
       });
-      expect(result).toEqual({
-        ...existing,
+      expect(result).toMatchObject({
+        key: 'k1',
         description: 'new desc',
         simple_value: 'v',
       });

--- a/server/researchindicators/src/domain/entities/app-config/app-config.service.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.service.ts
@@ -1,9 +1,14 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { AppConfig } from './entities/app-config.entity';
-import { cleanObject, isEmpty } from '../../shared/utils/object.utils';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
-import { CurrentUserUtil } from '../../shared/utils/current-user.util';
+import {
+  CurrentUserUtil,
+  SetAuditEnum,
+} from '../../shared/utils/current-user.util';
+import { UpdateAppConfigDto } from './dtos/update-app-config.dto';
+import { AppConfigRepository } from './repositories/app-config.repository';
+import { AppConfigSorting } from './enum/app-config-forting.enum';
 
 @Injectable()
 export class AppConfigService {
@@ -11,6 +16,7 @@ export class AppConfigService {
   constructor(
     private readonly dataSource: DataSource,
     private readonly currentUserUtil: CurrentUserUtil,
+    private readonly appConfigRepository: AppConfigRepository,
   ) {
     this.mainRepo = this.dataSource.getRepository(AppConfig);
   }
@@ -21,7 +27,7 @@ export class AppConfigService {
     });
   }
 
-  async updateConfig(key: string, updateData: Partial<AppConfig>) {
+  async updateConfig(key: string, updateData: UpdateAppConfigDto) {
     const config = await this.mainRepo.findOne({
       where: { key },
     });
@@ -29,23 +35,38 @@ export class AppConfigService {
       throw new NotFoundException(`Config with key ${key} not found`);
     }
 
-    const objToUpdate = cleanObject(updateData);
-    const update: QueryDeepPartialEntity<AppConfig> = {};
-
-    if (!isEmpty(objToUpdate?.description)) {
-      update.description = objToUpdate.description;
-    }
-
-    if (!isEmpty(objToUpdate?.simple_value)) {
-      update.simple_value = objToUpdate.simple_value;
-    }
-
-    if (!isEmpty(objToUpdate?.json_value)) {
-      update.json_value = objToUpdate.json_value;
-    }
+    const update: QueryDeepPartialEntity<AppConfig> = {
+      simple_value: updateData?.simple_value,
+      json_value: updateData?.json_value,
+      description: updateData?.description,
+      category: updateData?.category,
+      subcategory: updateData?.subcategory,
+      ...this.currentUserUtil.audit(SetAuditEnum.UPDATE),
+    };
 
     await this.mainRepo.update(config.key, update);
 
     return { ...config, ...update };
+  }
+
+  async getAllConfigs(
+    filters: { category?: string; subcategory?: string },
+    sorting?: { field?: AppConfigSorting; order?: 'ASC' | 'DESC' },
+    pagination?: { page?: number; limit?: number },
+    search?: string,
+  ): Promise<AppConfig[]> {
+    return this.appConfigRepository.findAll(
+      filters,
+      sorting ?? {},
+      pagination,
+      search,
+    );
+  }
+
+  async getCategoriesAndSubcategories(): Promise<{
+    categories: string[];
+    subcategories: string[];
+  }> {
+    return this.appConfigRepository.findAllCategoriesAndSubcategories();
   }
 }

--- a/server/researchindicators/src/domain/entities/app-config/app-config.service.ts
+++ b/server/researchindicators/src/domain/entities/app-config/app-config.service.ts
@@ -7,7 +7,10 @@ import {
   SetAuditEnum,
 } from '../../shared/utils/current-user.util';
 import { UpdateAppConfigDto } from './dtos/update-app-config.dto';
-import { AppConfigRepository } from './repositories/app-config.repository';
+import {
+  AppConfigFindAllResult,
+  AppConfigRepository,
+} from './repositories/app-config.repository';
 import { AppConfigSorting } from './enum/app-config-forting.enum';
 
 @Injectable()
@@ -54,7 +57,7 @@ export class AppConfigService {
     sorting?: { field?: AppConfigSorting; order?: 'ASC' | 'DESC' },
     pagination?: { page?: number; limit?: number },
     search?: string,
-  ): Promise<AppConfig[]> {
+  ): Promise<AppConfigFindAllResult> {
     return this.appConfigRepository.findAll(
       filters,
       sorting ?? {},

--- a/server/researchindicators/src/domain/entities/app-config/dtos/update-app-config.dto.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/dtos/update-app-config.dto.spec.ts
@@ -1,0 +1,41 @@
+import { validate } from 'class-validator';
+import { UpdateAppConfigDto } from './update-app-config.dto';
+
+describe('UpdateAppConfigDto', () => {
+  it('accepts a valid partial update', async () => {
+    const dto = Object.assign(new UpdateAppConfigDto(), {
+      simple_value: 'https://example.com/app',
+      description: 'Bulk upload embed URL',
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects XSS in simple_value', async () => {
+    const dto = Object.assign(new UpdateAppConfigDto(), {
+      simple_value: '<script>alert(1)</script>',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'simple_value')).toBe(true);
+  });
+
+  it('rejects unsafe json_value payloads', async () => {
+    const dto = Object.assign(new UpdateAppConfigDto(), {
+      json_value: JSON.parse('{"__proto__": {"admin": true}}'),
+    });
+
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'json_value')).toBe(true);
+  });
+
+  it('rejects invalid category characters', async () => {
+    const dto = Object.assign(new UpdateAppConfigDto(), {
+      category: 'BULK; DROP TABLE',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'category')).toBe(true);
+  });
+});

--- a/server/researchindicators/src/domain/entities/app-config/dtos/update-app-config.dto.ts
+++ b/server/researchindicators/src/domain/entities/app-config/dtos/update-app-config.dto.ts
@@ -1,0 +1,73 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import {
+  IsSafeStoredContent,
+  IsSafeStoredJson,
+} from '../../../shared/validators/is-safe-stored-content.validator';
+
+const CATEGORY_PATTERN = /^[A-Za-z0-9_.-]+$/;
+
+export class UpdateAppConfigDto {
+  @ApiProperty({
+    type: String,
+    description: 'The description of the app config',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(10_000)
+  @IsSafeStoredContent()
+  description?: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'The value of the app config',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(10_000)
+  @IsSafeStoredContent()
+  simple_value?: string;
+
+  @ApiProperty({
+    type: Object,
+    description: 'The value of the app config',
+  })
+  @IsObject()
+  @IsOptional()
+  @IsSafeStoredJson()
+  json_value?: object;
+
+  @ApiProperty({
+    type: String,
+    description: 'The category of the app config',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  @Matches(CATEGORY_PATTERN, {
+    message:
+      'category must contain only letters, numbers, underscores, dots, and hyphens',
+  })
+  @IsSafeStoredContent()
+  category?: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'The subcategory of the app config',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  @Matches(CATEGORY_PATTERN, {
+    message:
+      'subcategory must contain only letters, numbers, underscores, dots, and hyphens',
+  })
+  @IsSafeStoredContent()
+  subcategory?: string;
+}

--- a/server/researchindicators/src/domain/entities/app-config/entities/app-config.entity.ts
+++ b/server/researchindicators/src/domain/entities/app-config/entities/app-config.entity.ts
@@ -36,6 +36,7 @@ export class AppConfig extends AuditableEntity {
     type: 'text',
     nullable: true,
     name: 'field',
+    select: false,
   })
   field: string;
 

--- a/server/researchindicators/src/domain/entities/app-config/enum/app-config-forting.enum.ts
+++ b/server/researchindicators/src/domain/entities/app-config/enum/app-config-forting.enum.ts
@@ -1,0 +1,5 @@
+export enum AppConfigSorting {
+  CATEGORY = 'category',
+  SUBCATEGORY = 'subcategory',
+  KEY = 'key',
+}

--- a/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.spec.ts
@@ -1,0 +1,115 @@
+import { DataSource } from 'typeorm';
+import { AppConfigRepository } from './app-config.repository';
+import { AppConfigSorting } from '../enum/app-config-forting.enum';
+
+describe('AppConfigRepository', () => {
+  let repository: AppConfigRepository;
+  const query = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const dataSource = {
+      createEntityManager: jest.fn().mockReturnValue({}),
+    } as unknown as DataSource;
+    repository = new AppConfigRepository(dataSource);
+    repository.query = query;
+  });
+
+  describe('findAll', () => {
+    it('should list active configs with sort and no search params', async () => {
+      const rows = [{ key: 'k1' }];
+      query.mockResolvedValue(rows);
+
+      const result = await repository.findAll(
+        {},
+        { field: AppConfigSorting.KEY, order: 'ASC' },
+      );
+
+      const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).not.toContain('_search_relevance');
+      expect(sql).toContain('WHERE ac.is_active = TRUE');
+      expect(sql).toContain('ORDER BY ac.`key` ASC');
+      expect(params).toEqual([]);
+      expect(result).toBe(rows);
+    });
+
+    it('should apply filters and pagination', async () => {
+      query.mockResolvedValue([]);
+
+      await repository.findAll(
+        { category: 'EMAIL', subcategory: 'READINESS_LEVEL_7' },
+        { field: AppConfigSorting.CATEGORY, order: 'DESC' },
+        { page: 2, limit: 5 },
+      );
+
+      const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('ac.category = ?');
+      expect(sql).toContain('ac.subcategory = ?');
+      expect(sql).toContain('LIMIT 5 OFFSET 5');
+      expect(sql).toContain('ORDER BY ac.category DESC');
+      expect(params).toEqual(['EMAIL', 'READINESS_LEVEL_7']);
+    });
+
+    it('should search with relevance, bind params in order, and strip score column', async () => {
+      query.mockResolvedValue([
+        { key: 'email.to', category: 'EMAIL', _search_relevance: 2000 },
+      ]);
+
+      const result = await repository.findAll(
+        { category: 'EMAIL' },
+        { field: AppConfigSorting.KEY, order: 'ASC' },
+        { page: 1, limit: 20 },
+        '  email  ',
+      );
+
+      const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('_search_relevance');
+      expect(sql).toContain('ORDER BY _search_relevance DESC, ac.`key` ASC');
+      expect(sql).toContain('LIMIT 20 OFFSET 0');
+      expect(params).toEqual([
+        ...Array(9).fill('email'),
+        'EMAIL',
+        ...Array(7).fill('email'),
+      ]);
+      expect(result).toEqual([{ key: 'email.to', category: 'EMAIL' }]);
+    });
+
+    it('should order by relevance only when search is set and sort field is missing', async () => {
+      query.mockResolvedValue([{ key: 'k' }]);
+
+      await repository.findAll({}, {}, undefined, 'term');
+
+      const [sql] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('ORDER BY _search_relevance DESC');
+      expect(sql).not.toContain('ORDER BY _search_relevance DESC,');
+    });
+
+    it('should ignore blank search', async () => {
+      query.mockResolvedValue([]);
+
+      await repository.findAll({}, {}, undefined, '   ');
+
+      const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).not.toContain('_search_relevance');
+      expect(params).toEqual([]);
+    });
+  });
+
+  describe('findAllCategoriesAndSubcategories', () => {
+    it('should map distinct categories and subcategories', async () => {
+      query
+        .mockResolvedValueOnce([{ category: 'EMAIL' }, { category: 'OTHER' }])
+        .mockResolvedValueOnce([{ subcategory: 'READINESS_LEVEL_7' }]);
+
+      const result = await repository.findAllCategoriesAndSubcategories();
+
+      expect(query).toHaveBeenCalledTimes(2);
+      expect(query.mock.calls[0][0]).toContain('DISTINCT category');
+      expect(query.mock.calls[1][0]).toContain('DISTINCT subcategory');
+      expect(result).toEqual({
+        categories: ['EMAIL', 'OTHER'],
+        subcategories: ['READINESS_LEVEL_7'],
+      });
+    });
+  });
+});

--- a/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.spec.ts
+++ b/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.spec.ts
@@ -6,6 +6,17 @@ describe('AppConfigRepository', () => {
   let repository: AppConfigRepository;
   const query = jest.fn();
 
+  const paginationMeta = (overrides: Record<string, unknown> = {}) => ({
+    total: 0,
+    page: 1,
+    limit: 0,
+    pageSize: 0,
+    totalPages: 0,
+    hasNextPage: false,
+    hasPreviousPage: false,
+    ...overrides,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     const dataSource = {
@@ -16,44 +27,95 @@ describe('AppConfigRepository', () => {
   });
 
   describe('findAll', () => {
-    it('should list active configs with sort and no search params', async () => {
+    it('should list active configs with sort and pagination metadata', async () => {
       const rows = [{ key: 'k1' }];
-      query.mockResolvedValue(rows);
+      query.mockResolvedValueOnce(rows);
 
       const result = await repository.findAll(
         {},
         { field: AppConfigSorting.KEY, order: 'ASC' },
       );
 
+      expect(query).toHaveBeenCalledTimes(1);
       const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).not.toContain('SELECT COUNT(*)');
       expect(sql).not.toContain('_search_relevance');
       expect(sql).toContain('WHERE ac.is_active = TRUE');
       expect(sql).toContain('ORDER BY ac.`key` ASC');
+      expect(sql).not.toContain('LIMIT');
       expect(params).toEqual([]);
-      expect(result).toBe(rows);
+      expect(result).toEqual({
+        data: rows,
+        pagination: paginationMeta({
+          total: 1,
+          limit: 1,
+          pageSize: 1,
+          totalPages: 1,
+        }),
+      });
     });
 
-    it('should apply filters and pagination', async () => {
-      query.mockResolvedValue([]);
+    it('should return all rows when limit is not provided', async () => {
+      const rows = [{ key: 'k1' }, { key: 'k2' }];
+      query.mockResolvedValueOnce(rows);
 
-      await repository.findAll(
+      const result = await repository.findAll({}, {}, { page: 3 });
+
+      expect(query).toHaveBeenCalledTimes(1);
+      const [sql] = query.mock.calls[0] as [string, unknown[]];
+      expect(sql).not.toContain('LIMIT');
+      expect(sql).not.toContain('SELECT COUNT(*)');
+      expect(result.pagination).toEqual(
+        paginationMeta({
+          total: 2,
+          page: 1,
+          limit: 2,
+          pageSize: 2,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        }),
+      );
+    });
+
+    it('should apply filters and pagination when limit is set', async () => {
+      query.mockResolvedValueOnce([{ total: 12 }]).mockResolvedValueOnce([]);
+
+      const result = await repository.findAll(
         { category: 'EMAIL', subcategory: 'READINESS_LEVEL_7' },
         { field: AppConfigSorting.CATEGORY, order: 'DESC' },
         { page: 2, limit: 5 },
       );
 
-      const [sql, params] = query.mock.calls[0] as [string, unknown[]];
-      expect(sql).toContain('ac.category = ?');
-      expect(sql).toContain('ac.subcategory = ?');
-      expect(sql).toContain('LIMIT 5 OFFSET 5');
+      const [countSql, countParams] = query.mock.calls[0] as [
+        string,
+        unknown[],
+      ];
+      const [sql, params] = query.mock.calls[1] as [string, unknown[]];
+      expect(countSql).toContain('ac.category = ?');
+      expect(countSql).toContain('ac.subcategory = ?');
+      expect(countParams).toEqual(['EMAIL', 'READINESS_LEVEL_7']);
+      expect(sql).toContain('LIMIT ? OFFSET ?');
       expect(sql).toContain('ORDER BY ac.category DESC');
-      expect(params).toEqual(['EMAIL', 'READINESS_LEVEL_7']);
+      expect(params).toEqual(['EMAIL', 'READINESS_LEVEL_7', 5, 5]);
+      expect(result.pagination).toEqual(
+        paginationMeta({
+          total: 12,
+          page: 2,
+          limit: 5,
+          totalPages: 3,
+          hasNextPage: true,
+          hasPreviousPage: true,
+        }),
+      );
     });
 
     it('should search with relevance, bind params in order, and strip score column', async () => {
-      query.mockResolvedValue([
-        { key: 'email.to', category: 'EMAIL', _search_relevance: 2000 },
-      ]);
+      query
+        .mockResolvedValueOnce([{ total: 1 }])
+        .mockResolvedValueOnce([
+          { key: 'email.to', category: 'EMAIL', _search_relevance: 2000 },
+        ]);
 
       const result = await repository.findAll(
         { category: 'EMAIL' },
@@ -62,35 +124,48 @@ describe('AppConfigRepository', () => {
         '  email  ',
       );
 
-      const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+      const [sql, params] = query.mock.calls[1] as [string, unknown[]];
       expect(sql).toContain('_search_relevance');
       expect(sql).toContain('ORDER BY _search_relevance DESC, ac.`key` ASC');
-      expect(sql).toContain('LIMIT 20 OFFSET 0');
+      expect(sql).toContain('LIMIT ? OFFSET ?');
       expect(params).toEqual([
         ...Array(9).fill('email'),
         'EMAIL',
         ...Array(7).fill('email'),
+        20,
+        0,
       ]);
-      expect(result).toEqual([{ key: 'email.to', category: 'EMAIL' }]);
+      expect(result).toEqual({
+        data: [{ key: 'email.to', category: 'EMAIL' }],
+        pagination: paginationMeta({
+          total: 1,
+          limit: 20,
+          pageSize: 1,
+          totalPages: 1,
+        }),
+      });
     });
 
     it('should order by relevance only when search is set and sort field is missing', async () => {
-      query.mockResolvedValue([{ key: 'k' }]);
+      query.mockResolvedValueOnce([]);
 
       await repository.findAll({}, {}, undefined, 'term');
 
+      expect(query).toHaveBeenCalledTimes(1);
       const [sql] = query.mock.calls[0] as [string, unknown[]];
       expect(sql).toContain('ORDER BY _search_relevance DESC');
       expect(sql).not.toContain('ORDER BY _search_relevance DESC,');
     });
 
     it('should ignore blank search', async () => {
-      query.mockResolvedValue([]);
+      query.mockResolvedValueOnce([]);
 
       await repository.findAll({}, {}, undefined, '   ');
 
+      expect(query).toHaveBeenCalledTimes(1);
       const [sql, params] = query.mock.calls[0] as [string, unknown[]];
       expect(sql).not.toContain('_search_relevance');
+      expect(sql).not.toContain('SELECT COUNT(*)');
       expect(params).toEqual([]);
     });
   });

--- a/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.ts
+++ b/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.ts
@@ -1,0 +1,192 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { AppConfig } from '../entities/app-config.entity';
+import { AppConfigSorting } from '../enum/app-config-forting.enum';
+
+@Injectable()
+export class AppConfigRepository extends Repository<AppConfig> {
+  private static readonly FIND_APP_CONFIG_SEARCH_WHERE_PLACEHOLDER_COUNT = 7;
+
+  private static readonly FIND_APP_CONFIG_SEARCH_RELEVANCE_PLACEHOLDER_COUNT = 9;
+
+  constructor(private readonly dataSource: DataSource) {
+    super(AppConfig, dataSource.createEntityManager());
+  }
+
+  private getFiltersQuery(filters: {
+    category?: string;
+    subcategory?: string;
+  }): { fragment: string; params: string[] } {
+    const conditions: string[] = [];
+    const params: string[] = [];
+
+    if (filters?.category) {
+      conditions.push('ac.category = ?');
+      params.push(filters.category);
+    }
+    if (filters?.subcategory) {
+      conditions.push('ac.subcategory = ?');
+      params.push(filters.subcategory);
+    }
+
+    return {
+      fragment: conditions.length ? `AND ${conditions.join(' AND ')}` : '',
+      params,
+    };
+  }
+
+  /**
+   * Text search across list-visible columns (aligned with SELECT projection).
+   */
+  private buildFindAppConfigSearchWhereFragment(): string {
+    return `
+    AND (
+      ac.\`key\` LIKE CONCAT('%', ?, '%')
+      OR ac.category LIKE CONCAT('%', ?, '%')
+      OR ac.subcategory LIKE CONCAT('%', ?, '%')
+      OR ac.description LIKE CONCAT('%', ?, '%')
+      OR ac.simple_value LIKE CONCAT('%', ?, '%')
+      OR CAST(ac.json_value AS CHAR) LIKE CONCAT('%', ?, '%')
+      OR CONCAT_WS('', su.first_name, ' ', su.last_name) LIKE CONCAT('%', ?, '%')
+    )`;
+  }
+
+  /**
+   * Relevance for app-config text search (aligned with search WHERE).
+   * Non-key clauses use the full search string; key uses exact, prefix, then contains.
+   */
+  private buildFindAppConfigSearchRelevanceSelectFragment(): string {
+    return `, (
+      (CASE WHEN ac.\`key\` = ? THEN 2000 ELSE 0 END) +
+      (CASE WHEN ac.\`key\` LIKE CONCAT(?, '%') THEN 900 ELSE 0 END) +
+      (CASE WHEN ac.\`key\` LIKE CONCAT('%', ?, '%') THEN 700 ELSE 0 END) +
+      (CASE WHEN ac.description LIKE CONCAT('%', ?, '%') THEN 550 ELSE 0 END) +
+      (CASE WHEN ac.category LIKE CONCAT('%', ?, '%') THEN 450 ELSE 0 END) +
+      (CASE WHEN ac.subcategory LIKE CONCAT('%', ?, '%') THEN 400 ELSE 0 END) +
+      (CASE WHEN ac.simple_value LIKE CONCAT('%', ?, '%') THEN 380 ELSE 0 END) +
+      (CASE WHEN CAST(ac.json_value AS CHAR) LIKE CONCAT('%', ?, '%') THEN 320 ELSE 0 END) +
+      (CASE WHEN CONCAT_WS('', su.first_name, ' ', su.last_name) LIKE CONCAT('%', ?, '%') THEN 220 ELSE 0 END)
+    ) AS _search_relevance`;
+  }
+
+  private getSortingQuery(
+    sorting: { field?: AppConfigSorting; order?: 'ASC' | 'DESC' },
+    hasSearch: boolean,
+  ): string {
+    const fieldMap = {
+      [AppConfigSorting.CATEGORY]: 'ac.category',
+      [AppConfigSorting.SUBCATEGORY]: 'ac.subcategory',
+      [AppConfigSorting.KEY]: 'ac.`key`',
+    };
+    const direction = sorting?.order?.toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+
+    if (hasSearch) {
+      if (!sorting?.field || !fieldMap[sorting.field]) {
+        return 'ORDER BY _search_relevance DESC';
+      }
+      return `ORDER BY _search_relevance DESC, ${fieldMap[sorting.field]} ${direction}`;
+    }
+
+    if (!sorting?.field || !fieldMap[sorting.field]) return '';
+    return `ORDER BY ${fieldMap[sorting.field]} ${direction}`;
+  }
+
+  private getPaginationQuery(pagination?: {
+    page?: number;
+    limit?: number;
+  }): string {
+    if (!pagination?.page || !pagination?.limit) return '';
+    const page = !pagination?.page || pagination.page < 1 ? 1 : pagination.page;
+    const limit = !pagination?.limit ? 100 : pagination.limit;
+    const offset = (page - 1) * limit;
+    return `LIMIT ${limit} OFFSET ${offset}`;
+  }
+
+  async findAll(
+    filters: { category?: string; subcategory?: string },
+    sorting: { field?: AppConfigSorting; order?: 'ASC' | 'DESC' },
+    pagination?: { page?: number; limit?: number },
+    search?: string,
+  ): Promise<AppConfig[]> {
+    const trimmedSearch = search?.trim() ?? '';
+    const hasSearch = trimmedSearch.length > 0;
+
+    const { fragment: filtersQuery, params: filterParams } =
+      this.getFiltersQuery(filters);
+    const sortingQuery = this.getSortingQuery(sorting, hasSearch);
+    const paginationQuery = this.getPaginationQuery(pagination);
+
+    const searchWhereFragment = hasSearch
+      ? this.buildFindAppConfigSearchWhereFragment()
+      : '';
+    const relevanceFragment = hasSearch
+      ? this.buildFindAppConfigSearchRelevanceSelectFragment()
+      : '';
+
+    const searchWhereParams = hasSearch
+      ? Array(
+          AppConfigRepository.FIND_APP_CONFIG_SEARCH_WHERE_PLACEHOLDER_COUNT,
+        ).fill(trimmedSearch)
+      : [];
+    const relevanceParams = hasSearch
+      ? Array(
+          AppConfigRepository.FIND_APP_CONFIG_SEARCH_RELEVANCE_PLACEHOLDER_COUNT,
+        ).fill(trimmedSearch)
+      : [];
+
+    const query = `SELECT 
+                            ac.\`key\`,
+                            ac.category,
+                            ac.subcategory,
+                            ac.description,
+                            ac.simple_value,
+                            ac.json_value,
+                            ac.updated_at,
+                            IF(su.sec_user_id IS NULL, NULL, CONCAT_WS('', su.first_name, ' ', su.last_name)) updated_by
+                            ${relevanceFragment}
+                        FROM app_config ac 
+                        LEFT JOIN sec_users su ON su.sec_user_id = ac.updated_by 
+                        WHERE ac.is_active = TRUE
+                        ${filtersQuery}
+                        ${searchWhereFragment}
+                        ${sortingQuery}
+                        ${paginationQuery}`;
+
+    const queryParams = [
+      ...relevanceParams,
+      ...filterParams,
+      ...searchWhereParams,
+    ];
+
+    const rawData = await this.query(query, queryParams);
+
+    if (!hasSearch) {
+      return rawData;
+    }
+
+    return rawData.map((row: Record<string, unknown>) => {
+      const { _search_relevance: _r, ...rest } = row;
+      return rest as unknown as AppConfig;
+    });
+  }
+
+  async findAllCategoriesAndSubcategories(): Promise<{
+    categories: string[];
+    subcategories: string[];
+  }> {
+    const queryCategories = `SELECT DISTINCT category FROM app_config WHERE is_active = TRUE`;
+    const querySubcategories = `SELECT DISTINCT subcategory FROM app_config WHERE is_active = TRUE`;
+
+    const rawDataCategories = await this.query(queryCategories);
+    const rawDataSubcategories = await this.query(querySubcategories);
+
+    return {
+      categories: rawDataCategories.map(
+        (row: Record<string, unknown>) => row.category as string,
+      ),
+      subcategories: rawDataSubcategories.map(
+        (row: Record<string, unknown>) => row.subcategory as string,
+      ),
+    };
+  }
+}

--- a/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.ts
+++ b/server/researchindicators/src/domain/entities/app-config/repositories/app-config.repository.ts
@@ -91,15 +91,54 @@ export class AppConfigRepository extends Repository<AppConfig> {
     return `ORDER BY ${fieldMap[sorting.field]} ${direction}`;
   }
 
-  private getPaginationQuery(pagination?: {
-    page?: number;
-    limit?: number;
-  }): string {
-    if (!pagination?.page || !pagination?.limit) return '';
+  private resolvePagination(pagination?: { page?: number; limit?: number }): {
+    page: number;
+    limit: number | null;
+    applyLimit: boolean;
+    offset: number;
+  } {
+    const hasLimit =
+      pagination?.limit !== undefined &&
+      pagination?.limit !== null &&
+      Number(pagination.limit) > 0;
     const page = !pagination?.page || pagination.page < 1 ? 1 : pagination.page;
-    const limit = !pagination?.limit ? 100 : pagination.limit;
-    const offset = (page - 1) * limit;
-    return `LIMIT ${limit} OFFSET ${offset}`;
+
+    if (!hasLimit) {
+      return { page: 1, limit: null, applyLimit: false, offset: 0 };
+    }
+
+    const limit = Number(pagination.limit);
+    return {
+      page,
+      limit,
+      applyLimit: true,
+      offset: (page - 1) * limit,
+    };
+  }
+
+  private buildFindAllFromAndWhere(
+    filtersQuery: string,
+    searchWhereFragment: string,
+  ): string {
+    return `FROM app_config ac 
+                        LEFT JOIN sec_users su ON su.sec_user_id = ac.updated_by 
+                        WHERE ac.is_active = TRUE
+                        ${filtersQuery}
+                        ${searchWhereFragment}`;
+  }
+
+  private mapFindAllRows(
+    rawData: Record<string, unknown>[],
+    hasSearch: boolean,
+  ): AppConfig[] {
+    if (!hasSearch) {
+      return rawData as unknown as AppConfig[];
+    }
+
+    return rawData.map((row) => {
+      const { _search_relevance: _r, ...rest } = row;
+      return rest as unknown as AppConfig;
+    });
   }
 
   async findAll(
@@ -107,14 +146,15 @@ export class AppConfigRepository extends Repository<AppConfig> {
     sorting: { field?: AppConfigSorting; order?: 'ASC' | 'DESC' },
     pagination?: { page?: number; limit?: number },
     search?: string,
-  ): Promise<AppConfig[]> {
+  ): Promise<AppConfigFindAllResult> {
     const trimmedSearch = search?.trim() ?? '';
     const hasSearch = trimmedSearch.length > 0;
 
     const { fragment: filtersQuery, params: filterParams } =
       this.getFiltersQuery(filters);
     const sortingQuery = this.getSortingQuery(sorting, hasSearch);
-    const paginationQuery = this.getPaginationQuery(pagination);
+    const { page, limit, applyLimit, offset } =
+      this.resolvePagination(pagination);
 
     const searchWhereFragment = hasSearch
       ? this.buildFindAppConfigSearchWhereFragment()
@@ -134,6 +174,12 @@ export class AppConfigRepository extends Repository<AppConfig> {
         ).fill(trimmedSearch)
       : [];
 
+    const fromAndWhere = this.buildFindAllFromAndWhere(
+      filtersQuery,
+      searchWhereFragment,
+    );
+
+    const paginationClause = applyLimit ? 'LIMIT ? OFFSET ?' : '';
     const query = `SELECT 
                             ac.\`key\`,
                             ac.category,
@@ -144,30 +190,49 @@ export class AppConfigRepository extends Repository<AppConfig> {
                             ac.updated_at,
                             IF(su.sec_user_id IS NULL, NULL, CONCAT_WS('', su.first_name, ' ', su.last_name)) updated_by
                             ${relevanceFragment}
-                        FROM app_config ac 
-                        LEFT JOIN sec_users su ON su.sec_user_id = ac.updated_by 
-                        WHERE ac.is_active = TRUE
-                        ${filtersQuery}
-                        ${searchWhereFragment}
+                        ${fromAndWhere}
                         ${sortingQuery}
-                        ${paginationQuery}`;
+                        ${paginationClause}`;
 
     const queryParams = [
       ...relevanceParams,
       ...filterParams,
       ...searchWhereParams,
+      ...(applyLimit ? [limit, offset] : []),
     ];
 
-    const rawData = await this.query(query, queryParams);
-
-    if (!hasSearch) {
-      return rawData;
+    let total: number;
+    if (applyLimit) {
+      const countQuery = `SELECT COUNT(*) AS total ${fromAndWhere}`;
+      const countParams = [...filterParams, ...searchWhereParams];
+      const totalResult = await this.query(countQuery, countParams);
+      total = Number(totalResult?.[0]?.total ?? 0);
     }
 
-    return rawData.map((row: Record<string, unknown>) => {
-      const { _search_relevance: _r, ...rest } = row;
-      return rest as unknown as AppConfig;
-    });
+    const rawData = await this.query(query, queryParams);
+    const data = this.mapFindAllRows(rawData, hasSearch);
+
+    if (!applyLimit) {
+      total = data.length;
+    }
+
+    const effectiveLimit = applyLimit ? limit : total;
+    const totalPages =
+      effectiveLimit > 0 ? Math.ceil(total / effectiveLimit) : 0;
+    const responsePage = applyLimit ? page : 1;
+
+    return {
+      data,
+      pagination: {
+        total,
+        page: responsePage,
+        limit: effectiveLimit,
+        pageSize: data.length,
+        totalPages,
+        hasNextPage: applyLimit && responsePage < totalPages,
+        hasPreviousPage: applyLimit && responsePage > 1,
+      },
+    };
   }
 
   async findAllCategoriesAndSubcategories(): Promise<{
@@ -189,4 +254,19 @@ export class AppConfigRepository extends Repository<AppConfig> {
       ),
     };
   }
+}
+
+export interface AppConfigFindAllPagination {
+  total: number;
+  page: number;
+  limit: number;
+  pageSize: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface AppConfigFindAllResult {
+  data: AppConfig[];
+  pagination: AppConfigFindAllPagination;
 }

--- a/server/researchindicators/src/domain/shared/utils/safe-stored-content.util.spec.ts
+++ b/server/researchindicators/src/domain/shared/utils/safe-stored-content.util.spec.ts
@@ -1,0 +1,60 @@
+import {
+  containsDangerousStoredString,
+  isSafeStoredJsonPayload,
+  isSafeStoredString,
+} from './safe-stored-content.util';
+
+describe('safe-stored-content.util', () => {
+  describe('isSafeStoredString', () => {
+    it('accepts normal text and URLs', () => {
+      expect(isSafeStoredString('Configurable date-time rules')).toBe(true);
+      expect(isSafeStoredString('https://datb5ly7vwnl2.cloudfront.net/')).toBe(
+        true,
+      );
+    });
+
+    it('rejects script and event-handler patterns', () => {
+      expect(isSafeStoredString('<script>alert(1)</script>')).toBe(false);
+      expect(isSafeStoredString('javascript:alert(1)')).toBe(false);
+      expect(isSafeStoredString('<img src=x onerror=alert(1)>')).toBe(false);
+    });
+
+    it('rejects null bytes', () => {
+      expect(isSafeStoredString('safe\u0000payload')).toBe(false);
+    });
+  });
+
+  describe('containsDangerousStoredString', () => {
+    it('detects encoded angle brackets', () => {
+      expect(containsDangerousStoredString('\\u003cscript')).toBe(true);
+    });
+  });
+
+  describe('isSafeStoredJsonPayload', () => {
+    it('accepts nested configuration objects', () => {
+      expect(
+        isSafeStoredJsonPayload({
+          locale: 'en-US',
+          timezone: { iana: 'Europe/Paris' },
+        }),
+      ).toBe(true);
+    });
+
+    it('rejects prototype pollution keys', () => {
+      expect(
+        isSafeStoredJsonPayload(
+          JSON.parse('{"__proto__": {"polluted": true}}') as object,
+        ),
+      ).toBe(false);
+      expect(
+        isSafeStoredJsonPayload({ nested: { constructor: { x: 1 } } }),
+      ).toBe(false);
+    });
+
+    it('rejects dangerous strings inside JSON', () => {
+      expect(
+        isSafeStoredJsonPayload({ label: '<script>alert(1)</script>' }),
+      ).toBe(false);
+    });
+  });
+});

--- a/server/researchindicators/src/domain/shared/utils/safe-stored-content.util.ts
+++ b/server/researchindicators/src/domain/shared/utils/safe-stored-content.util.ts
@@ -1,0 +1,100 @@
+/** Max nesting depth when scanning json_value payloads. */
+export const SAFE_STORED_JSON_MAX_DEPTH = 32;
+
+/** Max serialized size (bytes) for json_value payloads. */
+export const SAFE_STORED_JSON_MAX_BYTES = 512_000;
+
+const FORBIDDEN_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Patterns that indicate XSS, script injection, or other unsafe stored content.
+ * Intentionally narrower than query-sanitizer SQL rules so URLs and normal text stay valid.
+ */
+const DANGEROUS_STRING_PATTERNS: RegExp[] = [
+  /\0/,
+  /<script\b/i,
+  /<\/script>/i,
+  /<iframe\b/i,
+  /<object\b/i,
+  /<embed\b/i,
+  /<\s*img[^>]+on\w+/i,
+  /javascript\s*:/i,
+  /vbscript\s*:/i,
+  /data\s*:\s*text\/html/i,
+  /\bon\w+\s*=/i,
+  /expression\s*\(/i,
+  /<\?php/i,
+  /<%[\s@]/,
+  /\\u003c/i,
+];
+
+export function containsDangerousStoredString(text: string): boolean {
+  return DANGEROUS_STRING_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isSafeStoredString(text: string): boolean {
+  if (typeof text !== 'string') {
+    return false;
+  }
+  return !containsDangerousStoredString(text);
+}
+
+export function isSafeStoredJsonValue(value: unknown, depth = 0): boolean {
+  if (depth > SAFE_STORED_JSON_MAX_DEPTH) {
+    return false;
+  }
+
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return isSafeStoredString(value);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((item) => isSafeStoredJsonValue(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Reflect.ownKeys(record).every((key) => {
+      if (typeof key !== 'string') {
+        return false;
+      }
+      if (FORBIDDEN_JSON_KEYS.has(key)) {
+        return false;
+      }
+      return isSafeStoredJsonValue(record[key], depth + 1);
+    });
+  }
+
+  return false;
+}
+
+export function isSafeStoredJsonPayload(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  let serializedLength = 0;
+  try {
+    serializedLength = Buffer.byteLength(JSON.stringify(value), 'utf8');
+  } catch {
+    return false;
+  }
+
+  if (serializedLength > SAFE_STORED_JSON_MAX_BYTES) {
+    return false;
+  }
+
+  return isSafeStoredJsonValue(value);
+}

--- a/server/researchindicators/src/domain/shared/validators/is-safe-stored-content.validator.ts
+++ b/server/researchindicators/src/domain/shared/validators/is-safe-stored-content.validator.ts
@@ -1,0 +1,74 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import {
+  isSafeStoredJsonPayload,
+  isSafeStoredString,
+} from '../utils/safe-stored-content.util';
+
+@ValidatorConstraint({ name: 'isSafeStoredContent', async: false })
+export class IsSafeStoredContentConstraint
+  implements ValidatorConstraintInterface
+{
+  validate(value: unknown): boolean {
+    if (value === null || value === undefined || value === '') {
+      return true;
+    }
+    if (typeof value !== 'string') {
+      return false;
+    }
+    return isSafeStoredString(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} contains disallowed or potentially unsafe content`;
+  }
+}
+
+export function IsSafeStoredContent(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      name: 'isSafeStoredContent',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: IsSafeStoredContentConstraint,
+    });
+  };
+}
+
+@ValidatorConstraint({ name: 'isSafeStoredJson', async: false })
+export class IsSafeStoredJsonConstraint
+  implements ValidatorConstraintInterface
+{
+  validate(value: unknown): boolean {
+    if (value === null || value === undefined) {
+      return true;
+    }
+    return isSafeStoredJsonPayload(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} contains disallowed keys or potentially unsafe content`;
+  }
+}
+
+export function IsSafeStoredJson(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      name: 'isSafeStoredJson',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: IsSafeStoredJsonConstraint,
+    });
+  };
+}


### PR DESCRIPTION
# App Configuration — List, Search, and Admin API Enhancements

## Summary

This PR extends the **App Configuration** module with two new read endpoints for the admin panel, a dedicated repository layer with search and pagination, and hardened validation for configuration updates. It also broadens update permissions to include `SYSTEM_ADMIN`.

**Commits included:**

- `d08c627` — Core implementation: `getAllConfigs`, `getCategoriesAndSubcategories`, repository, DTO, and safe-content validation
- `090e22e` — Pagination and response structure refinements for `getAllConfigs`

---

## Motivation

The admin panel needs to browse, filter, search, and paginate application configuration entries (`app_config`) instead of relying only on single-key lookups. This development introduces a list API with relevance-based search, category/subcategory metadata, and safer update payloads.

---

## What's New

### 1. `GET /api/configuration` — List configurations

Returns active configuration entries with optional filtering, text search, sorting, and pagination.

| Query param   | Type   | Default | Description                                                                                                                  |
| ------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
| `search`      | string | —       | Text search across `key`, `category`, `subcategory`, `description`, `simple_value`, `json_value`, and updater full name    |
| `category`    | string | —       | Filter by exact category                                                                                                     |
| `subcategory` | string | —       | Filter by exact subcategory                                                                                                  |
| `page`        | number | —       | 1-based page number. **Only applies when `limit` is set**                                                                    |
| `limit`       | number | —       | Page size. **When omitted, all matching rows are returned**                                                                  |
| `sort-field`  | enum   | `key`   | `category`, `subcategory`, or `key`                                                                                          |
| `sort-order`  | enum   | `ASC`   | `ASC` or `DESC`                                                                                                              |

**Search behavior:**

- When `search` is provided, results are ranked by a relevance score (exact key match > key prefix > key contains > description > category > subcategory > values > updater name).
- Secondary sort uses `sort-field` / `sort-order` after relevance.
- Blank or whitespace-only `search` is ignored.

**Pagination behavior:**

- If `limit` is not provided (or is invalid), **all matching rows** are returned in a single response; `page` is ignored.
- If `limit` is provided, a `COUNT(*)` query runs first, then `LIMIT` / `OFFSET` are applied.
- Pagination metadata is always included in the response payload.

**Response fields per item:**
`key`, `category`, `subcategory`, `description`, `simple_value`, `json_value`, `updated_at`, `updated_by` (full name from `sec_users` join).

### 2. `GET /api/configuration/categories-and-subcategories`

Returns distinct `categories` and `subcategories` from active configuration rows. Intended for filter dropdowns in the admin UI.

```json
{
  "categories": ["EMAIL", "OTHER"],
  "subcategories": ["READINESS_LEVEL_7"]
}
```

### 3. `PATCH /api/configuration/:key` — Hardened updates

Existing update endpoint improvements:

- Replaces raw `AppConfig` entity body with **`UpdateAppConfigDto`** and `ValidationPipe` (`whitelist`, `forbidNonWhitelisted`, `transform`).
- Adds **`SYSTEM_ADMIN`** alongside `TECHNICAL_SUPPORT` for update authorization.
- Validates stored content against XSS/injection patterns via `@IsSafeStoredContent` and `@IsSafeStoredJson`.
- Enforces `category` / `subcategory` pattern: `[A-Za-z0-9_.-]+`.
- Max length: 10,000 chars for text fields; 255 for category/subcategory.

---

## Response Envelope

All endpoints follow the standard `ServerResponseDto` envelope. For the list endpoint, `data` contains both rows and pagination:

```json
{
  "data": {
    "data": [
      {
        "key": "email.to",
        "category": "EMAIL",
        "subcategory": "READINESS_LEVEL_7",
        "description": "...",
        "simple_value": "...",
        "json_value": null,
        "updated_at": "2026-06-01T10:00:00.000Z",
        "updated_by": "Jane Doe"
      }
    ],
    "pagination": {
      "total": 42,
      "page": 2,
      "limit": 10,
      "pageSize": 10,
      "totalPages": 5,
      "hasNextPage": true,
      "hasPreviousPage": true
    }
  },
  "status": 200,
  "description": "Configurations retrieved successfully",
  "errors": null,
  "timestamp": "...",
  "path": "/api/configuration"
}
```

When pagination is not applied (`limit` omitted), `pagination.limit` equals `total`, `page` is `1`, and `hasNextPage` / `hasPreviousPage` are `false`.

---

## Architecture Changes

| Layer          | Change                                                                                                      |
| -------------- | ----------------------------------------------------------------------------------------------------------- |
| **Controller** | New `getAllConfigs` and `getCategoriesAndSubcategories` handlers; Swagger `@ApiOperation` / `@ApiQuery` on all endpoints |
| **Service**    | Delegates list/filter logic to `AppConfigRepository`; `updateConfig` now uses `UpdateAppConfigDto`          |
| **Repository** | New `AppConfigRepository` with raw SQL queries, relevance scoring, parameterized filters, and pagination resolution |
| **DTO**        | New `UpdateAppConfigDto` with class-validator decorators                                                    |
| **Shared utils** | New `safe-stored-content.util.ts` and `is-safe-stored-content.validator.ts` for stored-content safety checks |
| **Module**     | Registers and exports `AppConfigRepository`                                                                 |

---

## Authentication & Authorization

| Endpoint                                              | Auth                                      | Roles                              |
| ----------------------------------------------------- | ----------------------------------------- | ---------------------------------- |
| `GET /api/configuration`                              | **Required** (Bearer JWT or machine token) | Any authenticated user             |
| `GET /api/configuration/categories-and-subcategories` | **Required**                              | Any authenticated user             |
| `GET /api/configuration/:key`                         | **Public** (JWT middleware excluded)      | —                                  |
| `PATCH /api/configuration/:key`                       | **Required**                              | `TECHNICAL_SUPPORT`, `SYSTEM_ADMIN` |

> **Note:** Only `GET /api/configuration/:key` remains on the JWT middleware exclude list. The new list and categories endpoints require authentication.

---

## Files Changed

```
server/researchindicators/src/domain/entities/app-config/
├── app-config.controller.ts          (+ endpoints, Swagger, validation pipe)
├── app-config.controller.spec.ts     (+ unit tests)
├── app-config.service.ts             (+ getAllConfigs, getCategoriesAndSubcategories)
├── app-config.service.spec.ts        (+ unit tests)
├── app-config.module.ts              (+ AppConfigRepository)
├── dtos/update-app-config.dto.ts     (new)
├── dtos/update-app-config.dto.spec.ts (new)
├── entities/app-config.entity.ts     (minor)
├── enum/app-config-forting.enum.ts   (new — AppConfigSorting)
└── repositories/
    ├── app-config.repository.ts      (new)
    └── app-config.repository.spec.ts (new)

server/researchindicators/src/domain/shared/
├── utils/safe-stored-content.util.ts         (new)
├── utils/safe-stored-content.util.spec.ts    (new)
└── validators/is-safe-stored-content.validator.ts (new)
```

**Total:** ~1,175 lines added across 14 files (both commits combined).