### PR TITLE
fix(multiselect): persist nested OICR lever selections

### DIFF
--- a/client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -1,4 +1,4 @@
-@let list = this.signal()[this.signalOptionValue];
+@let list = this.selectedOptions();
 <div class="input-container">
   @if (label) {
   <label class="label inline-block flex items-center" for="username">{{ label }}

--- a/client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
+++ b/client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
@@ -1542,4 +1542,137 @@ describe('MultiselectComponent', () => {
       expect(spy).not.toHaveBeenCalled();
     });
   });
+
+  describe('Nested signal path write-through (bugfix regression)', () => {
+    let realComponent: MultiselectComponent;
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        providers: [
+          MultiselectComponent,
+          { provide: ElementRef, useValue: new ElementRef(document.createElement('div')) },
+          { provide: ActionsService, useValue: mockActionsService },
+          { provide: ServiceLocatorService, useValue: mockServiceLocator },
+          { provide: CacheService, useValue: mockCacheService },
+          UtilsService,
+          { provide: AllModalsService, useValue: mockAllModalsService }
+        ]
+      }).compileComponents();
+
+      realComponent = TestBed.inject(MultiselectComponent);
+      realComponent.optionValue = 'id';
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+    });
+
+    it('R-MNP-001 AC.1 — setValue on a nested path creates no dotted top-level key', () => {
+      realComponent.signal = signal({
+        group: { is_attending_organization: true, trainee_organization_representative: [] }
+      });
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+
+      realComponent.setValue([1, 2]);
+
+      expect(Object.keys(realComponent.signal()).some(key => key.includes('.'))).toBe(false);
+    });
+
+    it('R-MNP-001 AC.2 — nested selection is readable and clears required-invalid state', () => {
+      realComponent.signal = signal({
+        group: { is_attending_organization: true, trainee_organization_representative: [] }
+      });
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+      realComponent.isRequired = true;
+
+      realComponent.setValue([1, 2]);
+
+      expect(realComponent.selectedOptions().length).toBe(2);
+      expect(realComponent.isInvalid()).toBe(false);
+    });
+
+    it('R-MNP-001 AC.3 — sibling keys under the nested parent survive the write', () => {
+      realComponent.signal = signal({
+        group: { is_attending_organization: true, trainee_organization_representative: [] }
+      });
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+
+      realComponent.setValue([1, 2]);
+
+      expect(realComponent.signal().group.is_attending_organization).toBe(true);
+    });
+
+    it('R-MNP-002 AC.1 — selection survives effect flush (body stays [1, 2])', () => {
+      realComponent.signal = signal({
+        group: { is_attending_organization: true, trainee_organization_representative: [] }
+      });
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+
+      realComponent.setValue([1, 2]);
+      TestBed.flushEffects();
+
+      expect(realComponent.body().value).toEqual([1, 2]);
+    });
+
+    it('R-MNP-003 — clear() empties the nested path and leaves no dotted key', () => {
+      realComponent.signal = signal({
+        group: {
+          is_attending_organization: true,
+          trainee_organization_representative: [{ id: 1 }, { id: 2 }]
+        }
+      });
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+
+      realComponent.clear();
+
+      expect(realComponent.signal().group.trainee_organization_representative).toEqual([]);
+      expect(Object.keys(realComponent.signal()).some(key => key.includes('.'))).toBe(false);
+    });
+
+    it('R-MNP-004 AC.1/2/4 — flat-path write is unchanged: populated, new root reference, single-segment shape', () => {
+      realComponent.signal = signal({ flat_field: [] });
+      realComponent.signalOptionValue = 'flat_field';
+      const beforeRoot = realComponent.signal();
+
+      realComponent.setValue([1, 2]);
+
+      expect(realComponent.signal().flat_field.length).toBe(2);
+      expect(realComponent.selectedOptions().length).toBe(2);
+      expect(realComponent.signal()).not.toBe(beforeRoot);
+      expect(Object.keys(realComponent.signal()).sort()).toEqual(['flat_field']);
+    });
+
+    it('R-MNP-005 AC.1/2 — missing or null intermediate segment does not throw', () => {
+      realComponent.signal = signal({});
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+      expect(() => realComponent.setValue([1])).not.toThrow();
+      expect(realComponent.signal().group.trainee_organization_representative.length).toBe(1);
+
+      realComponent.signal = signal({ group: null });
+      expect(() => realComponent.setValue([1])).not.toThrow();
+      expect(realComponent.signal().group.trainee_organization_representative.length).toBe(1);
+    });
+
+    it('R-MNP-006 AC.2 — the template skeleton list (selectedOptions()) matches the nested selection count while options are still loading', () => {
+      realComponent.signal = signal({
+        group: { is_attending_organization: true, trainee_organization_representative: [] }
+      });
+      realComponent.signalOptionValue = 'group.trainee_organization_representative';
+
+      // `optionsSig()` defaults to an empty signal because `ngOnInit` (which binds it
+      // via `bindServiceSignals`/`loadData`) never runs against this bare `TestBed.inject`
+      // instance — this is exactly the loading branch the skeleton `@for` renders for
+      // (`currentResultIsLoading() || !optionsSig().length`, multiselect.component.html:95).
+      expect(realComponent.optionsSig().length).toBe(0);
+
+      realComponent.setValue([1, 2]);
+
+      // multiselect.component.html:1 now derives `list` — the skeleton `@for`'s only
+      // consumer — from `this.selectedOptions()`. Assert that value's length directly,
+      // since the mockless (real UtilsService) TestBed here has no component fixture
+      // to read the rendered DOM skeleton count from.
+      expect(realComponent.selectedOptions().length).toBe(2);
+    });
+  });
 });

--- a/client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
+++ b/client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
@@ -370,11 +370,33 @@ export class MultiselectComponent implements OnInit, OnChanges {
     if (this.service?.isOpenSearch()) this.service.update(event.filter);
   }
 
+  /**
+   * Clones the spine of `path` — the root plus every intermediate segment —
+   * and assigns `value` at the leaf, returning a **new** root reference.
+   * A missing or non-object intermediate segment is created as a plain
+   * object; an existing intermediate segment keeps its other keys. Mirrors
+   * `UtilsService.setNestedPropertyWithReduce`'s `acc[key] ??= {}` convention
+   * without its in-place mutation (see design.md D-OLD-1).
+   */
+  private writeAtPath(current: any, path: string, value: any): any {
+    const [key, ...rest] = path.split('.');
+
+    if (rest.length === 0) {
+      return { ...current, [key]: value };
+    }
+
+    const existingSegment = current?.[key];
+    const segment =
+      existingSegment && typeof existingSegment === 'object' && !Array.isArray(existingSegment) ? existingSegment : {};
+
+    return {
+      ...current,
+      [key]: this.writeAtPath(segment, rest.join('.'), value)
+    };
+  }
+
   clear() {
-    this.signal.update(prev => ({
-      ...prev,
-      [this.signalOptionValue]: []
-    }));
+    this.signal.update(prev => this.writeAtPath(prev, this.signalOptionValue, []));
     this.body.set({ value: null });
   }
 
@@ -398,7 +420,7 @@ export class MultiselectComponent implements OnInit, OnChanges {
         return merged as any;
       });
 
-      nextState = { ...current, [this.signalOptionValue]: nextItems };
+      nextState = this.writeAtPath(current, this.signalOptionValue, nextItems);
       return nextState;
     });
 

--- a/docs/specs/bugfix/oicr-lever-dropdowns/design.md
+++ b/docs/specs/bugfix/oicr-lever-dropdowns/design.md
@@ -1,0 +1,93 @@
+# Design — bugfix / oicr-lever-dropdowns
+
+- **Module:** client (shared component)
+- **Spec id:** 2026-08-oicr-lever-dropdowns
+- **Status:** draft
+- **Linked requirements:** ./requirements.md
+- **Depth:** Lite
+- **Last updated:** 2026-08-13
+
+---
+
+## 1. Goals & non-goals
+
+- **Goals:** (1) make `MultiselectComponent` write `signalOptionValue` symmetrically to how it reads it (nested path) so OICR-modal primary/contributing levers persist — R-OLD-001/002; (2) ship a regression suite red-before/green-after — R-OLD-* AC.
+- **Non-goals:** refactor beyond the minimal nested-write fix; touch the OICR form template or service; modify the OpenSearch variant; any server/data change.
+
+---
+
+## 2. Architecture
+
+No new files, no new modules. The change is surgical to the existing shared component:
+
+- `client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts`
+- `client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html`
+- `client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts`
+
+**Reuse:** the existing `selectedOptions` computed (already reads nested via `UtilsService.getNestedProperty`) and the existing `UtilsService.setNestedPropertyWithReduce` convention. The write side closes the read/write asymmetry that caused the bug.
+
+**Bug Mode constraint:** scope stays at the root cause. The OICR form that *passes* the dotted path (`create-oicr-form.component.html`) is a legitimate user of a nested body shape (`step_two.*`) and is not the defect — `app-multiselect` is.
+
+---
+
+## 3. Data model
+
+No data model changes. Server lever storage is unchanged.
+
+---
+
+## 4. API surface
+
+No API changes.
+
+---
+
+## 5. Workflows & business rules
+
+- OICR modal step 2 selecting a lever appends a `{lever_id, …}` object to the nested array via `setValue`; `clear` empties it.
+- Symmetry restored: `getNestedProperty` (read) ↔ `writeAtPath` (write). `writeAtPath` clones the spine (root + intermediate segments) and assigns at the leaf, returning a new root — immutable by construction (safe for Angular signals), mirroring `setNestedPropertyWithReduce`'s `acc[key] ??= {}` without its in-place mutation.
+- Cross-exclusion (`optionsDisabled`/`primaryOptionsDisabled` effects) is downstream of the nested body; once the write reaches the nested path, the existing effects fire unchanged.
+
+---
+
+## 8. Security & authorization
+
+No auth/authz surface touched.
+
+---
+
+## 10. Testing strategy
+
+- Unit: backport `describe('Nested signal path write-through (bugfix regression)')`, cases R-MNP-001…R-MNP-005 (red on current `main`, green after fix). Covers dotted-key absence, nested readable + required-invalid clear, sibling-key survival, effect-flush body persistence, `clear()` empties nested path, flat-path unchanged, missing/null intermediate.
+- Suite: run the **full** client suite (KZ-003) to confirm the shared-component change does not regress flat-path consumers.
+- Visual (gap): a HITL visual check of the live Create OICR modal step 2 confirms rendered chips/state — jsdom cannot measure rendering (see requirements §5).
+
+---
+
+## 12. Design decisions log
+
+| # | Date | Decision | Rationale |
+| --- | --- | --- | --- | 
+| D-OLD-1 | 2026-08-13 | Backport `writeAtPath` verbatim from `dev` (immutable spine-clone write) instead of in-place mutation or changing the dotted consumer | Smallest safe path; already shipped, reviewed, and regression-tested on `dev`; preserves angular-signal immutability by returning a new root reference each write |
+| D-OLD-2 | 2026-08-13 | Template read switches to existing `selectedOptions()` computed instead of flat `this.signal()[this.signalOptionValue]` | `selectedOptions` already resolves the nested path via `getNestedProperty`; the read side was never broken, aligning the template with it completes the read/write symmetry |
+| D-OLD-3 | 2026-08-13 | Keep the OICR dotted `signalOptionValue` contract (`step_two.primary_lever`) — do not flatten it | The nested `step_two.*` body shape is the server-expected contract; coercing the shared component to write nested is cheaper/safer than changing every consumer's body shape |
+
+Step 2.3 reversion challenge: no DD removes already-delivered behavior — all three ADD correction to broken behavior on `main`. No challenge required.
+
+---
+
+## 2.4 Budget (post-design re-check)
+
+| Metric | Estimate |
+| --- | --- |
+| Expected tasks | 1 (plus the implicit suite gate) |
+| Expected LOC | ~25 TS + ~20 spec lines backported + 1 template line |
+| Expected review rounds | 1 |
+
+Matches Lite — no escalation. `/akili-execute` trips when actuals exceed this.
+
+---
+
+## 13. Open questions
+
+- None.

--- a/docs/specs/bugfix/oicr-lever-dropdowns/proposal.md
+++ b/docs/specs/bugfix/oicr-lever-dropdowns/proposal.md
@@ -1,0 +1,195 @@
+# Proposal — OICR Modal Lever Dropdowns Selection Failure
+
+## Document Control
+
+| Field | Value |
+| --- | --- |
+| Spec Path | `bugfix/oicr-lever-dropdowns` |
+| Proposal Path | `docs/specs/bugfix/oicr-lever-dropdowns/proposal.md` |
+| Type | **Bug** |
+| Slug | `oicr-lever-dropdowns` — derived from free-text argument (modal de OICRS, dropdowns failing, primary & contributing levers) |
+| Approval Mode | `gated` |
+| Depends on | none |
+| Parallel-safe | yes |
+| Related Kaizen | KZ-002, KZ-003 |
+
+---
+
+## Intent
+
+Restore lever selection in the OICR creation modal on `main`/staging/prod so that **Primary Levers** and **Contributing Levers** can be selected and submitted, matching the behavior already working on `dev`.
+
+---
+
+## Problem / Current Behavior
+
+In the **Create OICR** modal (step 2 — Contributors), both the **Primary Levers** and **Contributing Levers** `<app-multiselect>` dropdowns fail on `main`/staging/prod: the user opens the dropdown, picks levers, but the selection **does not persist** into the nested form body, so the levers cannot be added and the form's step-2 completion / cross-exclusion / save logic never sees them.
+
+On `dev` (test environment) the same modal works correctly — levers are selected and saved without issue. This is a **regression** present only on `main`/staging/prod.
+
+> **Note:** Two screenshots were attached by the user but could not be read (the current session model does not support image input). The diagnosis below is confirmed from code investigation across branches, not from the screenshots.
+
+---
+
+## Proposed Outcome
+
+Selecting a primary or contributing lever in the Create OICR modal writes the selection into `createOicrBody().step_two.primary_lever` / `step_two.contributor_lever` (the nested path), so that:
+
+- the selected chips/state render inside the dropdown,
+- cross-exclusion between primary and contributing levers (`optionsDisabled` / `primaryOptionsDisabled`) updates,
+- step-2 completion validation passes,
+- the saved body contains the chosen levers.
+
+---
+
+## Scope
+
+**In scope:**
+
+- `MultiselectComponent` write path (`clear()`, `setValue()`) and template read path — fix the dotted/nested `signalOptionValue` handling.
+- Regression tests proving nested-path write-through (red on `main`, green after fix).
+
+**Out of scope (explicitly):**
+
+- Any change to the OICR form template, `createResultManagementService`, or the levers service — these are identical between `dev` and `main`; the bug is not there.
+- New features, lever taxonomy changes, or API contract changes.
+
+> KZ-002 applies: the defective component is a **shared** `app-multiselect` rendered inside the OICR route, not a file under the OICR feature folder. Scope was enumerated by *what renders on the route*, not by folder. KZ-003 applies: `app-multiselect` renders on many routes, so verification must be a **full client test suite** run, not a targeted one.
+
+---
+
+## Non-Goals
+
+- Refactoring the multiselect beyond the minimal nested-write fix.
+- Backporting unrelated `dev`-only changes (project dashboard, document overview services, api.service changes, etc.) that diverged from `main`.
+- Touching the OpenSearch-based `multiselect-opensearch` variant.
+
+---
+
+## Affected Users, Systems, And Specs
+
+| Layer | Impact |
+| --- | --- |
+| Users | Any OICR submitter/editor on staging/prod unable to complete step 2 of the Create OICR modal. |
+| Client | `shared/components/custom-fields/multiselect/multiselect.component.{ts,html}` — defective write path. |
+| Client (consumer) | `shared/.../create-result-modal/components/create-oicr-form/create-oicr-form.component.html` — passes dotted `signalOptionValue` (`step_two.primary_lever`, `step_two.contributor_lever`) that triggers the defect. |
+| Specs | None under `docs/specs/` currently cover this; this proposal seeds `bugfix/oicr-lever-dropdowns`. |
+
+Blast radius is bounded to dotted-path `signalOptionValue` consumers. `alliance-alignment.component.html` uses a **flat** `signalOptionValue="primary_levers"` and is unaffected by the flat-write path; only the OICR modal uses dotted paths.
+
+---
+
+## Visual Reference
+
+- Source: None (screenshots attached by the user are unreadable by this session model — no image input support; diagnosis confirmed from cross-branch code investigation).
+- Location: —
+- Notes: Backend-no-change / UI-only regression; visual is the existing Create OICR modal step 2. No mockup needed.
+
+---
+
+## Bug Diagnosis
+
+### Observed Symptom
+
+In the Create OICR modal step 2, the Primary Levers and Contributing Levers `<app-multiselect>` dropdowns let the user open and click options, but the selection **fails to register**: the chips/state do not persist as a real selection, cross-exclusion between primary and contributing levers doesn't update, and the saved body has empty lever arrays. On `dev` the same action works.
+
+### Reproduction Steps
+
+1. On `main`/staging/prod build, open the Create OICR modal and advance to step 2 (Contributors).
+2. Open the **Primary Levers** dropdown, select one or more levers.
+3. Expected: selection persists (chips/selected count render) and `createOicrBody().step_two.primary_lever` holds the chosen lever objects; the **Contributing Levers** dropdown disables already-chosen primary levers.
+4. Actual: selection does not persist into the nested body; `step_two.primary_lever` remains `[]`; contributing-lever cross-exclusion does not react. Same for Contributing Levers.
+5. On `dev`, step 4 behaves as expected (step 3).
+
+### Root Cause (confirmed)
+
+**`MultiselectComponent` on `main` treats the dotted `signalOptionValue` as a flat top-level key on write, while reading it as a nested path.** Confirmed by `git diff HEAD..origin/dev` on `multiselect.component.{ts,html}` — not a hypothesis: the fix exists and is regression-tested on `dev` but is absent from `main`.
+
+Defective code on `main` (`shared/components/custom-fields/multiselect/multiselect.component.ts`):
+
+- `clear()` (l. 373–378):
+  ```ts
+  this.signal.update(prev => ({ ...prev, [this.signalOptionValue]: [] }));
+  ```
+- `setValue()` (l. 381–406): reads the previous value **nested** via `this.utils.getNestedProperty(current, this.signalOptionValue)` (l. 387) but **writes flat**:
+  ```ts
+  nextState = { ...current, [this.signalOptionValue]: nextItems };
+  ```
+- Template (`multiselect.component.html` l. 1): `@let list = this.signal()[this.signalOptionValue];` — flat-key read.
+
+The OICR modal passes a **dotted** path: `signalOptionValue="step_two.primary_lever"` and `"step_two.contributor_lever"` (`create-oicr-form.component.html` l. 222, 263). Under the flat-write code:
+
+- `setValue` creates a spurious root key literally named `"step_two.primary_lever"` while leaving the **real** nested `body.step_two.primary_lever` untouched (`[]`).
+- Everything downstream reads the nested path (`createResultManagementService.createOicrBody().step_two?.primary_lever`, `step_two?.contributor_lever`) and sees empty arrays: cross-exclusion effects (`updateOptionsDisabledEffect` / `updatePrimaryOptionsDisabledEffect`), `isCompleteStepTwo`, `navigateToOicr`, and `mapLeversWithCustomNames` on save. So the lever selection is silently discarded.
+
+**`dev` fix (the backport target):**
+
+- Adds `private writeAtPath(current, path, value)` — clones the spine (`root…intermediate segments`) and assigns `value` at the leaf, mirroring `UtilsService.setNestedPropertyWithReduce`'s `acc[key] ??= {}` convention **without** in-place mutation (immutability preserved for signal change detection).
+- `clear()` and `setValue()` write via `writeAtPath(prev, this.signalOptionValue, …)` instead of the flat `[this.signalOptionValue]` spread.
+- Template reads `@let list = this.selectedOptions();` (the existing `selectedOptions` computed, l. 176 in `main`, which already resolves the nested path) instead of the flat `this.signal()[this.signalOptionValue]`.
+
+Regression tests already exist on `dev` (`multiselect.component.spec.ts`, `describe('Nested signal path write-through (bugfix regression)')`, cases R-MNP-001…R-MNP-005) covering: no dotted top-level key after `setValue`, nested selection readable + clears required-invalid, sibling keys under the parent survive, selection survives effect flush, `clear()` empties the nested path leaving no dotted key, flat-path write unchanged, and missing/null intermediate segment does not throw.
+
+### Impact & Scope
+
+- **Blast radius:** all consumers of `<app-multiselect>` that pass a **dotted** `signalOptionValue`. Today that is only the OICR creation modal's two lever fields. Flat-path consumers (e.g. `alliance-alignment.component.html` `primary_levers`) are unaffected by the flat-write code and remain unaffected by the nested-write fix (single-segment path is a trivial case).
+- **Data integrity:** OICRs created on prod are being submitted with **empty** lever arrays — a real data-quality issue, not just a UI glitch.
+- **No security implication.**
+
+### Fix Strategy
+
+**Smallest safe correction:** backport the `dev` multiselect changes verbatim to `main`:
+
+1. Add `writeAtPath` helper to `multiselect.component.ts`.
+2. Route `clear()` and `setValue()` writes through `writeAtPath`.
+3. Change the template line 1 to `@let list = this.selectedOptions();`.
+4. Backport the `Nested signal path write-through (bugfix regression)` spec block (R-MNP-001…005) to prove red-before/green-after.
+
+This is logic/data behavior change with a mandatory regression test, not a cosmetic one-liner — route: **`/akili-specify` (Lite) in Bug Mode**.
+
+---
+
+## Approach Options
+
+| # | Approach | Pros | Cons |
+| --- | --- | --- | --- |
+| **A (Recommended)** | Backport `dev`'s exact `writeAtPath` + template read fix + regression spec to `main`. | Minimal, already proven & tested on `dev`; no new design; immutable (signal-friendly); surgical to nested-path behavior. | Must ensure no unrelated `dev`-only changes leak in. |
+| B | Reimplement a nested-write fix from scratch on `main`. | Avoids any `dev` merge mechanics. | Re-invents an existing, reviewed, tested solution; higher regression risk; duplicates work. |
+| C | Change the OICR modal to use flat `signalOptionValue` (renaming the body shape) instead of fixing the shared component. | Avoids touching the shared component. | Breaks the `step_two.*` body contract that the server and the rest of the form expect; larger, riskier, wrong layer. |
+
+---
+
+## Recommended Approach
+
+**Option A** — verbatim backport of the `dev` `MultiselectComponent` nested-write fix and its regression spec. It is the smallest safe path: the fix already exists, is immutable (safe for Angular signals), is regression-tested, and is scoped to the shared component that KZ-002/KZ-003 say must be fixed-and-verified at the shared layer with a full-suite run.
+
+---
+
+## Risks, Dependencies, And Open Questions
+
+| Risk / Question | Mitigation |
+| --- | --- |
+| `app-multiselect` is rendered on many routes (KZ-003) — a shared-component change could affect flat-path consumers. | `writeAtPath` treats a single-segment path as a trivial leaf case; R-MNP-004 explicitly asserts flat-path write is unchanged. Run the **full** client test suite, not only the OICR/multiselect specs. |
+| Confirm screenshots (unreadable here) match the code-confirmed symptom. | Root cause is confirmed from cross-branch code diff independently of the screenshots; user should confirm the symptom description matches. |
+| Are there other dotted-`signalOptionValue` consumers silently broken today? | Grep for `signalOptionValue="….…"`; only the OICR modal uses dotted paths today. `/akili-specify` Bug Mode will add a guard test. |
+| Merge direction: ensure cherry-pick carries only the multiselect hunks, not adjacent `dev` changes (api.service, dashboard, document-overview). | Cherry-pick by file path, then `git diff` review against the accepted fix. |
+
+---
+
+## Success Criteria
+
+- On `main` build: selecting Primary and Contributing levers in the Create OICR modal persists into `createOicrBody().step_two.{primary_lever,contributor_lever}`.
+- Cross-exclusion between primary and contributing levers reacts to selections.
+- Step-2 completion validation passes when levers are chosen; the saved OICR body contains the chosen levers.
+- Backported regression tests R-MNP-001…005 are **red before** the fix and **green after**.
+- Full client suite (`npm test`) stays green; lint (`npm run lint -- --quiet`) stays clean.
+
+---
+
+## Next Step
+
+```text
+/akili-specify bugfix/oicr-lever-dropdowns
+```
+
+Run in **Bug Mode**: convert the confirmed root cause above into a fix plan (backport `writeAtPath` + template read + regression spec R-MNP-001…005), red-before/green-after.

--- a/docs/specs/bugfix/oicr-lever-dropdowns/requirements.md
+++ b/docs/specs/bugfix/oicr-lever-dropdowns/requirements.md
@@ -1,0 +1,105 @@
+# Requirements — bugfix / oicr-lever-dropdowns
+
+- **Module:** client (shared component)
+- **Spec id:** 2026-08-oicr-lever-dropdowns
+- **Status:** draft
+- **Owner:** <name / squad>
+- **Linked proposal:** ./proposal.md
+- **Type:** Bug (Bug Mode)
+- **Depth:** Lite
+- **Last updated:** 2026-08-13
+
+---
+
+## 1. Context
+
+On `main`/staging/prod, **Primary Levers** and **Contributing Levers** dropdowns in the Create OICR modal (step 2) let the user click options but the selection **does not persist** — `createOicrBody().step_two.{primary_lever,contributor_lever}` stays empty, so cross-exclusion, step-2 validation, and the saved body all see no levers. On `dev` (test env) the same modal works. Root cause confirmed in `proposal.md` Bug Diagnosis: `MultiselectComponent` on `main` writes a dotted `signalOptionValue` as a flat top-level key (creating spurious `"step_two.primary_lever"` root keys) while everything reads the nested path. This spec backports the already-tested `dev` fix.
+
+Not changing: the OICR form template, `createResultManagementService`, the levers service, the OpenSearch `multiselect-opensearch` variant, server code, data model.
+
+---
+
+## 2. Requirement numbering
+
+`R-OLD-<NNN>` — `OLD` = OICR Lever Dropdowns.
+
+---
+
+## 3. Functional requirements
+
+### R-OLD-001 — Nested-path lever selection writes through
+
+- **As an** OICR submitter
+- **I want** my Primary/Contributing Lever selection written into `step_two.primary_lever` / `step_two.contributor_lever`
+- **So that** cross-exclusion, step-2 validation, and the saved OICR body all see the chosen levers.
+
+**Behavior:**
+
+- Selecting levers in an `<app-multiselect>` whose `signalOptionValue` is a **dotted path** (`step_two.primary_lever`, `step_two.contributor_lever`) SHALL update the nested property, NOT create a top-level key whose name contains a dot.
+- Sibling keys under the nested parent (e.g. `step_two`'s other fields) MUST survive the write.
+- The new root reference MUST differ from the previous root (immutability for Angular signal change detection).
+- `setValue` reads the previous items via `getNestedProperty` (nested) and SHALL write symmetrically via a nested-path writer.
+- `clear()` SHALL empty the nested path (leaving `[]`), not create a dotted key.
+
+**Acceptance criteria:**
+
+- [ ] AC.1 — After `setValue([1,2])` on `signalOptionValue="step_two.primary_lever"`, no top-level key of `signal()` contains a `.`.
+- [ ] AC.2 — After `setValue([1,2])`, `signal().step_two.primary_lever` has length 2 and `selectedOptions().length` is 2 and required-invalid clears.
+- [ ] AC.3 — Sibling keys under `step_two` survive the write.
+- [ ] AC.4 — `clear()` empties `step_two.primary_lever` to `[]` and leaves no dotted key.
+- [ ] AC.5 — A flat `signalOptionValue="flat_field"` write keeps current behavior (no regression for flat-path consumers).
+
+**Out of scope:** changing the OICR body contract, server-side lever storage, other dropdown variants.
+
+---
+
+### R-OLD-002 — Missing/intermediate-path robustness
+
+- **As a** developer consuming the shared component
+- **I want** a dotted `signalOptionValue` to work when intermediate segments are missing or `null`
+- **So that** selection does not crash and the parent is created on demand.
+
+**Behavior:**
+
+- `setValue` on `signalOptionValue="group.trainee_organization_representative"` when `group` is absent or `null` SHALL create the intermediate object on the write path and not throw.
+
+**Acceptance criteria:**
+
+- [ ] AC.1 — `setValue([1])` against `{}` does not throw and yields `.group.trainee_organization_representative.length === 1`.
+- [ ] AC.2 — Against `{ group: null }`, same outcome and no throw.
+
+---
+
+## 4. Non-functional requirements
+
+### NFR-OLD-001 — No flat-path consumer regression (blast radius)
+
+- **Category:** reliability
+- **Target:** full client test suite stays green for every `<app-multiselect>` consumer (KZ-003: enumerate by what renders, KZ-002: shared component verified at shared layer).
+- **How verified:** `npm test` (full suite) — not a targeted multiselect-only run.
+
+---
+
+## 5. Defect classes & verification gates
+
+| Defect class this spec can produce | Catching command |
+| --- | --- |
+| Nested-path write regression (the bug itself) | `multiselect.component.spec.ts` R-MNP-001/003/005 — **red before fix, green after** |
+| Flat-path consumer regression from shared change | R-MNP-004 + full client `npm test` |
+| Cross-exclusion effect reaction after selection | existing `create-oicr-form.component.spec.ts` effects + full `npm test` |
+| Rendered chip/state visuals (jsdom cannot measure rendering) | **No automated check.** Substitute: human visual check at the HITL execution pause against the live Create OICR modal step 2. Recorded as a HITL gap, not collapsed into a green `npm test`. |
+
+Per the gate rule, the visual class has no automated gate; it is substituted by a HITL visual check. No T6 dispatch is needed — the logic/state fix is fully covered by jest; only the rendered affordance needs human eyes.
+
+---
+
+## 6. Assumptions, dependencies, risks
+
+- Confirmed `app-multiselect` is used on many routes (KZ-003); R-MNP-004 must stay green and full suite must pass.
+- Cherry-pick must carry only the multiselect + spec hunks, not adjacent `dev`-only divergence (api.service, dashboard, document-overview).
+
+---
+
+## 7. Open questions
+
+- None requiring another spec; the fix is already shipped-and-tested on `dev`.

--- a/docs/specs/bugfix/oicr-lever-dropdowns/tasks.md
+++ b/docs/specs/bugfix/oicr-lever-dropdowns/tasks.md
@@ -1,0 +1,89 @@
+# Tasks — bugfix / oicr-lever-dropdowns
+
+- **Module:** client (shared component)
+- **Spec id:** 2026-08-oicr-lever-dropdowns
+- **Status:** not-started
+- **Owner:** <name / squad>
+- **Linked requirements:** ./requirements.md
+- **Linked design:** ./design.md
+- **Depth:** Lite (Bug Mode)
+- **Last updated:** 2026-08-13
+
+---
+
+## 1. Task numbering
+
+Single task `T-01`. The mandatory regression test (Bug Mode) is part of `T-01`.
+
+---
+
+## 2. Dependency graph
+
+- `T-01` → (verification gate: full client suite)
+
+---
+
+## 3. Task list
+
+### T-01 — Backport nested-path write fix + regression suite for `MultiselectComponent`
+
+- **Requirements covered:** R-OLD-001 (AC.1–5), R-OLD-002 (AC.1–2), NFR-OLD-001
+- **Design references:** DD-1, DD-2, DD-3
+- **Files touched (intended):**
+  - `client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts` — add `private writeAtPath(current, path, value)`; route `clear()` and `setValue()` writes through it.
+  - `client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html` — change line 1 read to `@let list = this.selectedOptions();`.
+  - `client/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts` — append the `describe('Nested signal path write-through (bugfix regression)')` block with R-MNP-001…R-MNP-005.
+- **Description:** Cherry-pick the `dev` multiselect hunks (and only those). The fix restores read/write symmetry: the read side already uses `getNestedProperty` via the existing `selectedOptions` computed; the write side gains an immutable spine-clone `writeAtPath`. Do **not** pull adjacent `dev`-only divergence (api.service, dashboard, document-overview) — cherry-pick by file path and review the diff.
+- **Implementation notes:**
+  - `writeAtPath` returns a new root reference at every level (immutability for signals); single-segment path is the flat case (`rest.length === 0`).
+  - Missing/null intermediate segment → create `{}` (mirror `setNestedPropertyWithReduce`'s `acc[key] ??= {}`), never mutate in place.
+  - Do not change `create-oicr-form.component.html` dotted `signalOptionValue` — the contract is correct per DD-3.
+- **Tests (Bug Mode — regression, red before / green after):**
+  - Run `npm test -- --silent -t "Nested signal path write-through"` on current (un-fixed) `main`: R-MNP-001 AC.1, R-MNP-003, R-MNP-005 SHALL fail (red) proving the test can see the bug — e.g. R-MNP-001 asserts no top-level key contains `.`, which `main`'s flat write violates.
+  - After the fix: R-MNP-001…005 SHALL pass (green).
+- **Verification:**
+  - `npm test -- --silent -t "Nested signal path write-through"` — green.
+  - `npm test -- --silent` — **full** client suite green (KZ-003 blast-radius check; shared component renders on many routes).
+  - `npm run lint -- --quiet` — clean (note: this script carries `--fix` and mutates files; re-check `git status` after).
+  - HITL visual check: in a running Create OICR modal step 2, selecting a lever renders chips/state and persists — jsdom cannot measure rendering, so this is the substitute gate for the visual defect class (requirements §5).
+- **Disqualifiers (no-pass clause):** the suite is not evidence if the targeted regression run did not first show red on un-fixed `main` — if you never observed the failure, the test cannot prove the fix. The full-suite run is not evidence if it reports green but excluded any `<app-multiselect>`-consuming spec or any `create-oicr-form` effect spec — exclusion collapses the blast-radius check into a non-check. Report an inconclusive result instead of a pass.
+- **Input that would make the check fail:** an implementation that normalizes both sides before comparing so the dotted-key creation is hidden; or a `writeAtPath` that mutates the previous root in place (raises a non-prevent in Angular signals or silently zeroes out sibling keys) — caught by R-MNP-001/003 + the new-root-reference assertion in R-MNP-004.
+- **Done:**
+  - [ ] Regression run red on un-fixed `main`, green after the fix.
+  - [ ] Full client suite green; `create-oicr-form` effect specs unchanged-green.
+  - [ ] Lint clean.
+  - [ ] HITL visual check of the Create OICR modal step 2 passed.
+- **Dependencies:** none
+- **Estimated effort:** S
+- **Skills:** `angular-developer`, `systematic-debugging`
+- **Status:** implemented (unverified — see Execution Note)
+- **Execution Note (accepted-risk waiver, user mandate 2026-08-13):** the environment had **no `node_modules`** (client/server/root) during execution, so the mandatory Bug-Mode **red-before** observation and the full-suite **green-after** gate could not be run. Per explicit user mandate ("Apply fix blind, you verify later"), the fix was applied **without observing red first**. This incurs the exact risk Bug Mode's red clause exists to prevent: a regression test that does not actually fail on the broken code provides no evidence the fix is what makes it pass. The user accepts this gap; verification is deferred to a session with the stack installed. The waiver is **routine-progress-only** — it does not extend to the still-open HITL visual gate, which remains mandatory.
+
+---
+
+## Verification to run (deferred — user-owned)
+
+In a session with `client/research-indicators/node_modules` installed, in order, capturing **verbatim output as evidence**:
+
+1. **RED (proves the test sees the bug):** on the un-fixed `main` commit (git stash the fix, keep the spec), run
+   `npx jest --config jest.config.ts src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts -t "Nested signal path write-through"` — expect R-MNP-001 AC.1, R-MNP-003, R-MNP-005, R-MNP-006 to FAIL. If they pass on un-fixed code, the regression suite is not evidence — stop and report.
+2. **GREEN (proves the fix):** restore the fix, re-run the same command — expect all R-MNP-001…006 to PASS.
+3. **Blast radius (KZ-003, shared component on many routes):** `npm test -- --silent` — full client suite green; spot-check `create-oicr-form.component.spec.ts` effect specs unchanged-green.
+4. **Lint:** `npm run lint -- --quiet` (⚠️ carries `--fix` → mutates files; re-check `git status` after and discard unintended auto-fixes outside `multiselect/`).
+5. **HITL visual gate (mandatory — no automated substitute):** in a running Create OICR modal step 2, selecting a Primary Lever and a Contributing Lever renders chips/state, persists into the body, and cross-excludes between the two dropdowns. This is the substitute gate for the visual defect class — jsdom cannot measure rendering.
+
+---
+
+## 5. Execution conventions
+
+- PR from branch `bug-fix-oicr-form` targeted per repo flow; single PR (estimate ≪ 400 LOC).
+- PR title: `fix(multiselect): write dotted signalOptionValue as nested path so OICR lever selections persist`.
+
+---
+
+## 8. Done definition
+
+- [ ] T-01 done.
+- [ ] R-OLD-001 / R-OLD-002 / NFR-OLD-001 ACs all checked.
+- [ ] Bounded to root cause — no unrelated cleanup folded in (Bug Mode scope rule).
+- [ ] HITL visual gap (requirements §5) passed.


### PR DESCRIPTION
## Problem
In the Create OICR modal (step 2), selecting Primary or Contributing Levers didn't stick — the dropdown looked like it accepted a click, but the selection never actually saved. That's because the shared multiselect component wrote the selection to the wrong place: it saved it under a flat key like `"step_two.primary_lever"` instead of properly nesting it inside `step_two.primary_lever`, while everything else in the form was reading from the nested path. So the picked levers were silently lost.

## Solution
Made the multiselect component write to nested paths the same way it already reads from them:
- Added a `writeAtPath` helper that clones the nested structure immutably and writes the value at the correct nested location (instead of a flat dotted key).
- Updated `clear()` and `setValue()` to use this helper.
- Updated the template to read from the existing `selectedOptions()` computed (which already resolves nested paths correctly) instead of a flat lookup.
- Added regression tests covering nested writes, sibling-key preservation, missing/null intermediate segments, and confirming flat-path behavior is unchanged.
- Added supporting bugfix spec docs under `docs/specs/bugfix/oicr-lever-dropdowns/`.

This is a backport of a fix already working on `dev`.

### Testing
- Added regression suite `Nested signal path write-through (bugfix regression)` in `multiselect.component.spec.ts`.
- Full client test suite run and lint are recommended before merge (see `docs/specs/bugfix/oicr-lever-dropdowns/tasks.md` for the verification checklist); HITL visual check of the live Create OICR modal step 2 is still pending.